### PR TITLE
Add dashboard and GitHub stats

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -20,6 +20,7 @@
     "@icons-pack/react-simple-icons": "^9.7.0",
     "@neondatabase/serverless": "^0.10.4",
     "@next/third-parties": "^15.3.4",
+    "@octokit/rest": "^22.0.0",
     "@radix-ui/react-select": "^2.1.4",
     "@tanstack/react-query": "^5.81.2",
     "@trpc/client": "^11.4.2",

--- a/apps/blog/src/app/dashboard/page.tsx
+++ b/apps/blog/src/app/dashboard/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { StarIcon, CodeBracketIcon } from "@heroicons/react/24/solid";
+import { SiGithub } from "@icons-pack/react-simple-icons";
+import { MetricCard } from "@/components/metric-card";
+import { trpc } from "@/trpc/client";
+
+const Dashboard = () => {
+  const { data: followers, isLoading: followersLoading } =
+    trpc.github.getFollowers.useQuery();
+  const { data: stars, isLoading: starsLoading } =
+    trpc.github.getStars.useQuery();
+  const { data: contributions, isLoading: contributionsLoading } =
+    trpc.github.getContributions.useQuery();
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8">
+      <div className="space-y-4">
+        <h1 className="text-4xl font-bold">Dashboard</h1>
+        <p className="text-muted-foreground text-lg">
+          📊 Just sharing a quick snapshot of a few personal wins and milestones
+          I&#39;ve hit along the way—it’s been a fun ride so far!
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <MetricCard
+          title="GitHub Followers"
+          value={followersLoading ? "..." : (followers ?? 0)}
+          icon={<SiGithub className="size-8" />}
+        />
+        <MetricCard
+          title="GitHub Stars"
+          value={starsLoading ? "..." : (stars ?? 0)}
+          icon={<StarIcon className="size-8" />}
+        />
+        <MetricCard
+          title="Total Commits"
+          value={
+            contributionsLoading
+              ? "..."
+              : (contributions?.contributionsCollection
+                  .totalCommitContributions ?? 0)
+          }
+          icon={<CodeBracketIcon className="size-8" />}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/apps/blog/src/components/metric-card.tsx
+++ b/apps/blog/src/components/metric-card.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent } from "@/components/card";
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface MetricCardProps {
+  title: string;
+  value: number | string;
+  icon: ReactNode;
+  className?: string;
+}
+
+export const MetricCard = ({
+  title,
+  value,
+  icon,
+  className,
+}: MetricCardProps) => (
+  <Card className={cn("p-6", className)}>
+    <CardContent className="p-0">
+      <div className="flex flex-col items-center space-y-2">
+        <div className="flex items-center space-x-2">
+          {icon}
+          <span className="text-4xl font-bold">{value}</span>
+        </div>
+        <p className="text-muted-foreground text-sm">{title}</p>
+      </div>
+    </CardContent>
+  </Card>
+);

--- a/apps/blog/src/config/index.ts
+++ b/apps/blog/src/config/index.ts
@@ -15,6 +15,7 @@ export const SITE_DESCRIPTION =
 
 export const navLinks: NavLink[] = [
   { title: "Blog", href: "/blog" },
+  { title: "Dashboard", href: "/dashboard" },
   { title: "About", href: "/about" },
   { title: "Projects", href: "/projects" },
   // { title: "Resume", href: "/resume" },

--- a/apps/blog/src/lib/github.ts
+++ b/apps/blog/src/lib/github.ts
@@ -1,0 +1,79 @@
+import { Octokit } from "@octokit/rest";
+
+interface GithubContribution {
+  contributionsCollection: { totalCommitContributions: number };
+}
+
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN,
+});
+
+const GITHUB_USERNAME = "ruchernchong";
+
+const GITHUB_GRAPHQL_API = "https://api.github.com/graphql";
+
+export const getGitHubFollowers = async (): Promise<number> => {
+  try {
+    const { data } = await octokit.rest.users.getByUsername({
+      username: GITHUB_USERNAME,
+    });
+    return data.followers;
+  } catch (error) {
+    console.error("Error fetching GitHub followers:", error);
+    return 0;
+  }
+};
+
+export const getGitHubStars = async (): Promise<number> => {
+  try {
+    const { data } = await octokit.rest.repos.listForUser({
+      username: GITHUB_USERNAME,
+      per_page: 100,
+    });
+
+    return data.reduce((acc, repo) => acc + (repo.stargazers_count ?? 0), 0);
+  } catch (error) {
+    console.error("Error fetching GitHub stars:", error);
+    return 0;
+  }
+};
+
+export const getGitHubContributions =
+  async (): Promise<GithubContribution | null> => {
+    try {
+      const query = `
+      query {
+        user(login: "${GITHUB_USERNAME}") {
+          contributionsCollection {
+            totalCommitContributions
+            restrictedContributionsCount
+          }
+          repositoriesContributedTo(
+            first: 1
+            contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]
+          ) {
+            totalCount
+          }
+          pullRequests(first: 1) {
+            totalCount
+          }
+        }
+      }
+    `;
+
+      const response = await fetch(GITHUB_GRAPHQL_API, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query }),
+      });
+
+      const { data } = await response.json();
+      return data.user;
+    } catch (error) {
+      console.error("Error fetching GitHub contributions:", error);
+      return null;
+    }
+  };

--- a/apps/blog/src/server/index.ts
+++ b/apps/blog/src/server/index.ts
@@ -1,8 +1,10 @@
 import { router } from "@/server/trpc";
 import { analyticsRouter } from "@/server/routers/analytics";
+import { githubRouter } from "@/server/routers/github";
 
 export const appRouter = router({
   analytics: analyticsRouter,
+  github: githubRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/blog/src/server/routers/github.ts
+++ b/apps/blog/src/server/routers/github.ts
@@ -1,0 +1,12 @@
+import { publicProcedure, router } from "../trpc";
+import {
+  getGitHubFollowers,
+  getGitHubStars,
+  getGitHubContributions,
+} from "@/lib/github";
+
+export const githubRouter = router({
+  getFollowers: publicProcedure.query(() => getGitHubFollowers()),
+  getStars: publicProcedure.query(() => getGitHubStars()),
+  getContributions: publicProcedure.query(() => getGitHubContributions()),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@next/third-parties':
         specifier: ^15.3.4
         version: 15.3.4(next@15.3.4(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      '@octokit/rest':
+        specifier: ^22.0.0
+        version: 22.0.0
       '@radix-ui/react-select':
         specifier: ^2.1.4
         version: 2.1.4(@types/react-dom@19.0.2(@types/react@19.0.2))(@types/react@19.0.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1381,6 +1384,58 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.2':
+    resolution: {integrity: sha512-ODsoD39Lq6vR6aBgvjTnA3nZGliknKboc9Gtxr7E4WDNqY24MxANKcuDQSF0jzapvGb3KWOEDrKfve4HoWGK+g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.0':
+    resolution: {integrity: sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.1':
+    resolution: {integrity: sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
+  '@octokit/plugin-paginate-rest@13.1.0':
+    resolution: {integrity: sha512-16iNOa4rTTjaWtfsPGJcYYL79FJakseX8TQFIPfVuSPC3s5nkS/DSNQPFPc5lJHgEDBWNMxSApHrEymNblhA9w==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@16.0.0':
+    resolution: {integrity: sha512-kJVUQk6/dx/gRNLWUnAWKFs1kVPn5O5CYZyssyEoNYaFedqZxsfYs7DwI3d67hGz4qOwaJ1dpm07hOAD1BXx6g==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.0.0':
+    resolution: {integrity: sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.3':
+    resolution: {integrity: sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.0':
+    resolution: {integrity: sha512-z6tmTu9BTnw51jYGulxrlernpsQYXpui1RK21vmXn8yF5bp6iX16yfTtJYGK5Mh1qDkvDOmp2n8sRMcQmR8jiA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
+
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
@@ -2446,6 +2501,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -3181,6 +3239,9 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5207,6 +5268,9 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
@@ -6398,6 +6462,68 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.2':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.1
+      '@octokit/request': 10.0.3
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 14.1.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.0':
+    dependencies:
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.1':
+    dependencies:
+      '@octokit/request': 10.0.3
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@25.1.0': {}
+
+  '@octokit/plugin-paginate-rest@13.1.0(@octokit/core@7.0.2)':
+    dependencies:
+      '@octokit/core': 7.0.2
+      '@octokit/types': 14.1.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.2)':
+    dependencies:
+      '@octokit/core': 7.0.2
+
+  '@octokit/plugin-rest-endpoint-methods@16.0.0(@octokit/core@7.0.2)':
+    dependencies:
+      '@octokit/core': 7.0.2
+      '@octokit/types': 14.1.0
+
+  '@octokit/request-error@7.0.0':
+    dependencies:
+      '@octokit/types': 14.1.0
+
+  '@octokit/request@10.0.3':
+    dependencies:
+      '@octokit/endpoint': 11.0.0
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 14.1.0
+      fast-content-type-parse: 3.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.0':
+    dependencies:
+      '@octokit/core': 7.0.2
+      '@octokit/plugin-paginate-rest': 13.1.0(@octokit/core@7.0.2)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.2)
+      '@octokit/plugin-rest-endpoint-methods': 16.0.0(@octokit/core@7.0.2)
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
+
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -7387,6 +7513,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  before-after-hook@4.0.0: {}
+
   binary-extensions@2.3.0: {}
 
   brace-expansion@1.1.11:
@@ -8280,6 +8408,8 @@ snapshots:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
+
+  fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -10785,6 +10915,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+
+  universal-user-agent@7.0.3: {}
 
   update-browserslist-db@1.1.3(browserslist@4.24.5):
     dependencies:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a new dashboard page that displays GitHub followers, stars, and total commits using live data from the GitHub API.

- **New Features**
  - Dashboard page at /dashboard with metric cards for GitHub stats.
  - Backend integration to fetch followers, stars, and commit counts via GitHub API.
  - Updated navigation to include the dashboard link.

<!-- End of auto-generated description by cubic. -->

