### PR TITLE
chore(src): clean up lint and type safety

### DIFF
--- a/src/app/(main)/blog/_components/series-navigation.tsx
+++ b/src/app/(main)/blog/_components/series-navigation.tsx
@@ -43,7 +43,7 @@ function SeriesPostsList({
 }) {
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between gap-4 border-b border-border pb-2">
+      <div className="flex items-center justify-between gap-4 border-border border-b pb-2">
         <span className="font-medium text-sm">In this series</span>
         <Link
           href={`/blog?series=${seriesSlug}` as Route}
@@ -106,7 +106,7 @@ export function SeriesNavigation({
   return (
     <div
       className={cn(
-        "flex flex-col gap-4 border-b border-border pb-6",
+        "flex flex-col gap-4 border-border border-b pb-6",
         className,
       )}
     >

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -15,7 +15,7 @@ export default function NotFound() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, ease: "easeOut" }}
-          className="select-none text-[clamp(8rem,25vw,14rem)] font-bold leading-none tracking-tighter text-primary"
+          className="select-none font-bold text-[clamp(8rem,25vw,14rem)] text-primary leading-none tracking-tighter"
         >
           404
         </motion.h1>
@@ -27,7 +27,7 @@ export default function NotFound() {
           transition={{ duration: 0.5, ease: "easeOut", delay: 0.1 }}
           className="flex flex-col items-center gap-4 text-center"
         >
-          <p className="text-xl font-medium tracking-tight text-foreground">
+          <p className="font-medium text-foreground text-xl tracking-tight">
             This page has wandered off
           </p>
           <p className="max-w-md text-muted-foreground">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,10 +1,7 @@
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { APIError, createAuthMiddleware } from "better-auth/api";
 import { betterAuth } from "better-auth/minimal";
 import { nextCookies } from "better-auth/next-js";
 import { admin, lastLoginMethod, oAuthProxy } from "better-auth/plugins";
-import { eq } from "drizzle-orm";
-import * as schema from "@/schema";
 import { db } from "@/schema";
 
 /**

--- a/src/lib/services/__tests__/cache-invalidation.test.ts
+++ b/src/lib/services/__tests__/cache-invalidation.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CacheConfig } from "@/lib/config/cache.config";
 import * as postsQueries from "@/lib/queries/posts";
+import type { SelectPost } from "@/schema";
 
 // Mock dependencies
 vi.mock("@/config/redis", () => ({
@@ -27,6 +28,60 @@ import {
 } from "../cache-invalidation";
 import { removeFromPopular } from "../popular-posts";
 
+const createMockPost = (overrides: Partial<SelectPost>): SelectPost => ({
+  id: "post-id",
+  slug: "post-slug",
+  title: "Post title",
+  summary: null,
+  metadata: {
+    readingTime: "1 min",
+    description: "description",
+    canonical: "https://example.com/post",
+    openGraph: {
+      title: "Post title",
+      siteName: "Site",
+      description: "description",
+      type: "article",
+      publishedTime: "2024-01-01T00:00:00.000Z",
+      url: "https://example.com/post",
+      locale: "en_SG",
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: "@site",
+      title: "Post title",
+      description: "description",
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: "Post title",
+      dateModified: "2024-01-01T00:00:00.000Z",
+      datePublished: "2024-01-01T00:00:00.000Z",
+      description: "description",
+      url: "https://example.com/post",
+      author: {
+        "@type": "Person",
+        name: "Author",
+        url: "https://example.com",
+      },
+    },
+  },
+  content: "content",
+  status: "published",
+  tags: [],
+  featured: false,
+  coverImage: null,
+  authorId: null,
+  seriesId: null,
+  seriesOrder: null,
+  publishedAt: new Date("2024-01-01T00:00:00.000Z"),
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+  deletedAt: null,
+  ...overrides,
+});
+
 describe("cache-invalidation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,7 +89,7 @@ describe("cache-invalidation", () => {
 
   describe("invalidatePost", () => {
     it("should delete both stats and related cache for a post", async () => {
-      vi.mocked(redis.del).mockResolvedValue(undefined as any);
+      vi.mocked(redis.del).mockResolvedValue(2);
 
       await invalidatePost("test-post");
 
@@ -48,15 +103,15 @@ describe("cache-invalidation", () => {
   describe("invalidateRelatedByTags", () => {
     it("should invalidate related caches for all posts with overlapping tags", async () => {
       const mockPosts = [
-        { slug: "post-1", tags: ["typescript", "react"] },
-        { slug: "post-2", tags: ["typescript"] },
-        { slug: "post-3", tags: ["react", "testing"] },
+        createMockPost({ slug: "post-1", tags: ["typescript", "react"] }),
+        createMockPost({ slug: "post-2", tags: ["typescript"] }),
+        createMockPost({ slug: "post-3", tags: ["react", "testing"] }),
       ];
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue(
-        mockPosts as any,
+        mockPosts,
       );
-      vi.mocked(redis.del).mockResolvedValue(undefined as any);
+      vi.mocked(redis.del).mockResolvedValue(3);
 
       await invalidateRelatedByTags(["typescript", "react"]);
 
@@ -74,12 +129,12 @@ describe("cache-invalidation", () => {
 
     it("should exclude specified slug from invalidation", async () => {
       const mockPosts = [
-        { slug: "post-1", tags: ["typescript"] },
-        { slug: "post-2", tags: ["typescript"] },
+        createMockPost({ slug: "post-1", tags: ["typescript"] }),
+        createMockPost({ slug: "post-2", tags: ["typescript"] }),
       ];
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue(
-        mockPosts as any,
+        mockPosts,
       );
 
       await invalidateRelatedByTags(["typescript"], "excluded-post");
@@ -109,7 +164,7 @@ describe("cache-invalidation", () => {
   describe("invalidatePopularPost", () => {
     it("should remove from popular and invalidate post caches", async () => {
       vi.mocked(removeFromPopular).mockResolvedValue(undefined);
-      vi.mocked(redis.del).mockResolvedValue(undefined as any);
+      vi.mocked(redis.del).mockResolvedValue(2);
 
       await invalidatePopularPost("test-post");
 
@@ -123,7 +178,7 @@ describe("cache-invalidation", () => {
 
     it("should run operations in parallel", async () => {
       const removePromise = Promise.resolve();
-      const delPromise = Promise.resolve(undefined as any);
+      const delPromise = Promise.resolve(2);
 
       vi.mocked(removeFromPopular).mockReturnValue(removePromise);
       vi.mocked(redis.del).mockReturnValue(delPromise);

--- a/src/lib/services/__tests__/popular-posts.test.ts
+++ b/src/lib/services/__tests__/popular-posts.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CacheConfig } from "@/lib/config/cache.config";
 import * as postsQueries from "@/lib/queries/posts";
+import type { SelectPost } from "@/schema";
 
 // Mock dependencies
 vi.mock("next/cache", () => ({
@@ -47,6 +48,60 @@ import {
   updatePopularScore,
 } from "../popular-posts";
 
+const createMockPost = (overrides: Partial<SelectPost>): SelectPost => ({
+  id: "post-id",
+  slug: "post-slug",
+  title: "Post title",
+  summary: null,
+  metadata: {
+    readingTime: "1 min",
+    description: "description",
+    canonical: "https://example.com/post",
+    openGraph: {
+      title: "Post title",
+      siteName: "Site",
+      description: "description",
+      type: "article",
+      publishedTime: "2024-01-01T00:00:00.000Z",
+      url: "https://example.com/post",
+      locale: "en_SG",
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: "@site",
+      title: "Post title",
+      description: "description",
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: "Post title",
+      dateModified: "2024-01-01T00:00:00.000Z",
+      datePublished: "2024-01-01T00:00:00.000Z",
+      description: "description",
+      url: "https://example.com/post",
+      author: {
+        "@type": "Person",
+        name: "Author",
+        url: "https://example.com",
+      },
+    },
+  },
+  content: "content",
+  status: "published",
+  tags: [],
+  featured: false,
+  coverImage: null,
+  authorId: null,
+  seriesId: null,
+  seriesOrder: null,
+  publishedAt: new Date("2024-01-01T00:00:00.000Z"),
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+  deletedAt: null,
+  ...overrides,
+});
+
 describe("popular-posts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -64,34 +119,31 @@ describe("popular-posts", () => {
       ]);
 
       const mockDbPosts = [
-        {
+        createMockPost({
           id: "1",
           slug: "post-1",
           title: "Post 1",
           summary: "Summary 1",
           publishedAt: new Date("2024-01-01"),
-          metadata: { readingTime: "5 min" },
-        },
-        {
+        }),
+        createMockPost({
           id: "2",
           slug: "post-2",
           title: "Post 2",
           summary: "Summary 2",
           publishedAt: new Date("2024-01-02"),
-          metadata: { readingTime: "3 min" },
-        },
-        {
+        }),
+        createMockPost({
           id: "3",
           slug: "post-3",
           title: "Post 3",
           summary: "Summary 3",
           publishedAt: new Date("2024-01-03"),
-          metadata: { readingTime: "7 min" },
-        },
+        }),
       ];
 
       vi.mocked(postsQueries.getPublishedPostsBySlugs).mockResolvedValue(
-        mockDbPosts as any,
+        mockDbPosts,
       );
 
       const result = await getPopularPosts(3);
@@ -128,26 +180,24 @@ describe("popular-posts", () => {
       vi.mocked(redis.zrange).mockResolvedValue(["post-b", 50, "post-a", 100]);
 
       const mockDbPosts = [
-        {
+        createMockPost({
           id: "2",
           slug: "post-b",
           title: "Post B",
           summary: null,
           publishedAt: new Date(),
-          metadata: {},
-        },
-        {
+        }),
+        createMockPost({
           id: "1",
           slug: "post-a",
           title: "Post A",
           summary: null,
           publishedAt: new Date(),
-          metadata: {},
-        },
+        }),
       ];
 
       vi.mocked(postsQueries.getPublishedPostsBySlugs).mockResolvedValue(
-        mockDbPosts as any,
+        mockDbPosts,
       );
 
       const result = await getPopularPosts(2);
@@ -180,7 +230,9 @@ describe("popular-posts", () => {
     });
 
     it("should handle Redis returning null", async () => {
-      vi.mocked(redis.zrange).mockResolvedValue(null as any);
+      vi.mocked(redis.zrange).mockResolvedValue(
+        null as unknown as Awaited<ReturnType<typeof redis.zrange>>,
+      );
 
       const result = await getPopularPosts(5);
 
@@ -191,15 +243,14 @@ describe("popular-posts", () => {
       vi.mocked(redis.zrange).mockResolvedValue(["post-1", 100, "post-2", 75]);
 
       vi.mocked(postsQueries.getPublishedPostsBySlugs).mockResolvedValue([
-        {
+        createMockPost({
           id: "1",
           slug: "post-1",
           title: "Post 1",
           summary: null,
           publishedAt: new Date(),
-          metadata: {},
-        },
-      ] as any);
+        }),
+      ]);
 
       const result = await getPopularPosts(2);
 
@@ -210,7 +261,7 @@ describe("popular-posts", () => {
 
   describe("updatePopularScore", () => {
     it("should update score in Redis sorted set", async () => {
-      vi.mocked(redis.zadd).mockResolvedValue(undefined as any);
+      vi.mocked(redis.zadd).mockResolvedValue(1);
 
       await updatePopularScore("test-post", 150);
 
@@ -226,7 +277,7 @@ describe("popular-posts", () => {
 
   describe("removeFromPopular", () => {
     it("should remove post from Redis sorted set", async () => {
-      vi.mocked(redis.zrem).mockResolvedValue(undefined as any);
+      vi.mocked(redis.zrem).mockResolvedValue(1);
 
       await removeFromPopular("test-post");
 

--- a/src/lib/services/__tests__/post-stats.test.ts
+++ b/src/lib/services/__tests__/post-stats.test.ts
@@ -51,7 +51,7 @@ describe("post-stats", () => {
 
     it("should initialise default stats when cache is empty", async () => {
       vi.mocked(redis.get).mockResolvedValue(null);
-      vi.mocked(redis.set).mockResolvedValue(undefined as any);
+      vi.mocked(redis.set).mockResolvedValue("OK");
 
       const result = await getPostStats("new-post");
 
@@ -81,8 +81,8 @@ describe("post-stats", () => {
       };
 
       vi.mocked(redis.get).mockResolvedValue(existingStats);
-      vi.mocked(redis.set).mockResolvedValue(undefined as any);
-      vi.mocked(redis.zadd).mockResolvedValue(undefined as any);
+      vi.mocked(redis.set).mockResolvedValue("OK");
+      vi.mocked(redis.zadd).mockResolvedValue(1);
 
       const result = await incrementViews("test-post");
 
@@ -122,7 +122,7 @@ describe("post-stats", () => {
       };
 
       vi.mocked(redis.get).mockResolvedValue(existingStats);
-      vi.mocked(redis.set).mockResolvedValue(undefined as any);
+      vi.mocked(redis.set).mockResolvedValue("OK");
 
       const result = await incrementLikes("test-post", "user-hash-1");
 
@@ -149,7 +149,7 @@ describe("post-stats", () => {
       };
 
       vi.mocked(redis.get).mockResolvedValue(existingStats);
-      vi.mocked(redis.set).mockResolvedValue(undefined as any);
+      vi.mocked(redis.set).mockResolvedValue("OK");
 
       const result = await incrementLikes("test-post", "user-hash-1");
 
@@ -167,7 +167,7 @@ describe("post-stats", () => {
       };
 
       vi.mocked(redis.get).mockResolvedValue(existingStats);
-      vi.mocked(redis.set).mockResolvedValue(undefined as any);
+      vi.mocked(redis.set).mockResolvedValue("OK");
 
       const result = await incrementLikes("test-post", "user4");
 

--- a/src/lib/services/__tests__/related-posts.test.ts
+++ b/src/lib/services/__tests__/related-posts.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CacheConfig } from "@/lib/config/cache.config";
 import * as postsQueries from "@/lib/queries/posts";
+import type { SelectPost } from "@/schema";
 
 // Mock dependencies
 vi.mock("next/cache", () => ({
@@ -23,6 +24,60 @@ vi.mock("@/lib/queries/posts", () => ({
 // Import after mocks
 import redis from "@/config/redis";
 import { getRelatedPosts } from "../related-posts";
+
+const createMockPost = (overrides: Partial<SelectPost>): SelectPost => ({
+  id: "post-id",
+  slug: "post-slug",
+  title: "Post title",
+  summary: null,
+  metadata: {
+    readingTime: "1 min",
+    description: "description",
+    canonical: "https://example.com/post",
+    openGraph: {
+      title: "Post title",
+      siteName: "Site",
+      description: "description",
+      type: "article",
+      publishedTime: "2024-01-01T00:00:00.000Z",
+      url: "https://example.com/post",
+      locale: "en_SG",
+    },
+    twitter: {
+      card: "summary_large_image",
+      site: "@site",
+      title: "Post title",
+      description: "description",
+    },
+    structuredData: {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: "Post title",
+      dateModified: "2024-01-01T00:00:00.000Z",
+      datePublished: "2024-01-01T00:00:00.000Z",
+      description: "description",
+      url: "https://example.com/post",
+      author: {
+        "@type": "Person",
+        name: "Author",
+        url: "https://example.com",
+      },
+    },
+  },
+  content: "content",
+  status: "published",
+  tags: [],
+  featured: false,
+  coverImage: null,
+  authorId: null,
+  seriesId: null,
+  seriesOrder: null,
+  publishedAt: new Date("2024-01-01T00:00:00.000Z"),
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+  deletedAt: null,
+  ...overrides,
+});
 
 describe("related-posts", () => {
   beforeEach(() => {
@@ -55,35 +110,35 @@ describe("related-posts", () => {
 
     it("should calculate Jaccard similarity and cache result", async () => {
       vi.mocked(redis.get).mockResolvedValue(null);
-      vi.mocked(redis.set).mockResolvedValue(undefined as any);
+      vi.mocked(redis.set).mockResolvedValue("OK");
 
       vi.mocked(postsQueries.getPostBySlug).mockResolvedValue({
         tags: ["typescript", "react", "testing"],
-      } as any);
+      });
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue([
-        {
+        createMockPost({
           slug: "post-1",
           title: "Post 1",
           summary: "Summary 1",
           publishedAt: new Date("2024-01-01"),
           tags: ["typescript", "react"],
-        },
-        {
+        }),
+        createMockPost({
           slug: "post-2",
           title: "Post 2",
           summary: "Summary 2",
           publishedAt: new Date("2024-01-02"),
           tags: ["typescript"],
-        },
-        {
+        }),
+        createMockPost({
           slug: "post-3",
           title: "Post 3",
           summary: "Summary 3",
           publishedAt: new Date("2024-01-03"),
           tags: ["typescript", "react", "testing"],
-        },
-      ] as any);
+        }),
+      ]);
 
       const result = await getRelatedPosts("test-post", 4);
 
@@ -107,31 +162,31 @@ describe("related-posts", () => {
 
       vi.mocked(postsQueries.getPostBySlug).mockResolvedValue({
         tags: ["tag1", "tag2"],
-      } as any);
+      });
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue([
-        {
+        createMockPost({
           slug: "post-1",
           title: "Post 1",
           summary: null,
           publishedAt: new Date(),
           tags: ["tag1", "tag2"],
-        },
-        {
+        }),
+        createMockPost({
           slug: "post-2",
           title: "Post 2",
           summary: null,
           publishedAt: new Date(),
           tags: ["tag1"],
-        },
-        {
+        }),
+        createMockPost({
           slug: "post-3",
           title: "Post 3",
           summary: null,
           publishedAt: new Date(),
           tags: ["tag2"],
-        },
-      ] as any);
+        }),
+      ]);
 
       const result = await getRelatedPosts("test-post", 2);
 
@@ -143,24 +198,24 @@ describe("related-posts", () => {
 
       vi.mocked(postsQueries.getPostBySlug).mockResolvedValue({
         tags: ["tag1", "tag2", "tag3", "tag4"],
-      } as any);
+      });
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue([
-        {
+        createMockPost({
           slug: "high-similarity",
           title: "High",
           summary: null,
           publishedAt: new Date(),
           tags: ["tag1", "tag2", "tag3"],
-        },
-        {
+        }),
+        createMockPost({
           slug: "low-similarity",
           title: "Low",
           summary: null,
           publishedAt: new Date(),
           tags: ["tag1", "tag5", "tag6", "tag7", "tag8"],
-        },
-      ] as any);
+        }),
+      ]);
 
       const result = await getRelatedPosts("test-post", 10);
 
@@ -177,7 +232,7 @@ describe("related-posts", () => {
 
       vi.mocked(postsQueries.getPostBySlug).mockResolvedValue({
         tags: [],
-      } as any);
+      });
 
       const result = await getRelatedPosts("test-post");
 
@@ -201,17 +256,17 @@ describe("related-posts", () => {
 
       vi.mocked(postsQueries.getPostBySlug).mockResolvedValue({
         tags: ["a", "b", "c"],
-      } as any);
+      });
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue([
-        {
+        createMockPost({
           slug: "post-1",
           title: "Post 1",
           summary: null,
           publishedAt: new Date(),
           tags: ["a", "b"],
-        },
-      ] as any);
+        }),
+      ]);
 
       const result = await getRelatedPosts("test-post");
 
@@ -244,17 +299,17 @@ describe("related-posts", () => {
 
       vi.mocked(postsQueries.getPostBySlug).mockResolvedValue({
         tags: ["a", "b", "c"],
-      } as any);
+      });
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue([
-        {
+        createMockPost({
           slug: "identical",
           title: "Identical",
           summary: null,
           publishedAt: new Date(),
           tags: ["a", "b", "c"],
-        },
-      ] as any);
+        }),
+      ]);
 
       const result = await getRelatedPosts("test-post");
 
@@ -266,17 +321,17 @@ describe("related-posts", () => {
 
       vi.mocked(postsQueries.getPostBySlug).mockResolvedValue({
         tags: ["a", "b"],
-      } as any);
+      });
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue([
-        {
+        createMockPost({
           slug: "different",
           title: "Different",
           summary: null,
           publishedAt: new Date(),
           tags: ["c", "d"],
-        },
-      ] as any);
+        }),
+      ]);
 
       const result = await getRelatedPosts("test-post");
 
@@ -288,17 +343,17 @@ describe("related-posts", () => {
 
       vi.mocked(postsQueries.getPostBySlug).mockResolvedValue({
         tags: ["a", "b", "c"],
-      } as any);
+      });
 
       vi.mocked(postsQueries.getPostsWithOverlappingTags).mockResolvedValue([
-        {
+        createMockPost({
           slug: "partial",
           title: "Partial",
           summary: null,
           publishedAt: new Date(),
           tags: ["b", "c", "d"],
-        },
-      ] as any);
+        }),
+      ]);
 
       const result = await getRelatedPosts("test-post");
 

--- a/src/lib/services/media.service.ts
+++ b/src/lib/services/media.service.ts
@@ -220,12 +220,13 @@ export class MediaService {
       const conditions = includeDeleted ? [] : [isNull(media.deletedAt)];
 
       if (search) {
-        conditions.push(
-          or(
-            ilike(media.filename, `%${search}%`),
-            ilike(media.alt, `%${search}%`),
-          )!,
+        const searchCondition = or(
+          ilike(media.filename, `%${search}%`),
+          ilike(media.alt, `%${search}%`),
         );
+        if (searchCondition) {
+          conditions.push(searchCondition);
+        }
       }
 
       const mediaList = await db

--- a/src/mcp/tools/posts.tools.ts
+++ b/src/mcp/tools/posts.tools.ts
@@ -115,7 +115,14 @@ export function registerPostTools(server: McpServer): void {
         throw new Error("Either id or slug must be provided");
       }
 
-      const condition = id ? eq(posts.id, id) : eq(posts.slug, slug!);
+      const condition = id
+        ? eq(posts.id, id)
+        : slug
+          ? eq(posts.slug, slug)
+          : null;
+      if (!condition) {
+        throw new Error("Either id or slug must be provided");
+      }
 
       const [result] = await db
         .select()
@@ -485,7 +492,7 @@ export function registerPostTools(server: McpServer): void {
           id: published.id,
           slug: published.slug,
           title: published.title,
-          publishedAt: published.publishedAt!.toISOString(),
+          publishedAt: published.publishedAt?.toISOString(),
         },
       };
 


### PR DESCRIPTION
This PR cleans up src lint warnings and type-safety issues surfaced by Biome. It replaces unsafe any/non-null assertions in service tests and runtime code, and removes stale imports and class ordering issues. Lint, typecheck, and the updated service test suites pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened type safety and cleaned up lint across src. Replaced unsafe assertions, corrected Redis mock return types in tests, removed unused imports, and tweaked minor className order; also added safer guards in media and MCP tools.

- **Refactors**
  - Replaced any/non-null assertions in service tests with a typed createMockPost helper (SelectPost).
  - Corrected Redis mock return values (set → "OK", zadd/zrem/del → numbers, zrange handles null) to match the client.
  - Removed unused imports in auth and reordered Tailwind classes to satisfy lint rules.

- **Bug Fixes**
  - MediaService: build search condition without non-null assertion and only push when present.
  - MCP post tools: validate id/slug before building query; avoid non-null assertions and use optional chaining when serializing publishedAt.

<sup>Written for commit 8a7efd3815fb8c0e975220293c20577f7237b875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

