### PR TITLE
Migrate analytics to the @posthog/next package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ out/
 dist/
 
 # Environment variables
-.env
+.env.development.local
 .env.local
 .env.*.local
 !.env.example
@@ -79,3 +79,4 @@ coverage/
 .beads-credential-key
 .env*.local
 .vercel
+.env*

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@neondatabase/serverless": "^0.10.4",
     "@number-flow/react": "0.6.0",
     "@octokit/rest": "^22.0.0",
+    "@posthog/next": "0.4.67",
     "@shikijs/rehype": "^3.20.0",
     "@trpc/server": "^11.8.0",
     "@types/ua-parser-js": "^0.7.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.0
         version: 22.0.1
+      '@posthog/next':
+        specifier: 0.4.67
+        version: 0.4.67(@types/react@19.2.10)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.41))(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@shikijs/rehype':
         specifier: ^3.20.0
         version: 3.20.0
@@ -2272,8 +2275,35 @@ packages:
   '@posthog/core@1.28.0':
     resolution: {integrity: sha512-753giUMWuk602UtS101tDZuNcwiKkr+3UEhLgfOwHAk2W32n53knOxAjyWT0JwMq5/+0uSQ2y4uaZXQAxwvBSw==}
 
+  '@posthog/core@1.29.13':
+    resolution: {integrity: sha512-7Me5zaeAue/wmA364Go8ChYbsVAfNAHbtDxXopWu3D6hq9PVScUcauRgjD1njgvP8NzN91SrIllE+pri3XvJVw==}
+
+  '@posthog/next@0.4.67':
+    resolution: {integrity: sha512-uOJmHkwsQQGcP+QACsWjGQNOArSvA056qZ25nme7crHUMpDC14b2pBLvmw5ZI4eBJAIGgljgcnVbscOLSXEnbQ==}
+    peerDependencies:
+      '@vercel/functions': '>=1.0.0'
+      next: '>=13.0.0'
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      '@vercel/functions':
+        optional: true
+
+  '@posthog/react@1.9.1':
+    resolution: {integrity: sha512-tIGjs8WzKPrHQmSyM/2a3GoedQkttkxgmCsdn0kgy+6mIiSNk36FAFGKbWFJ7/Kln5bHwcM/MQhiGYbwQG8bQQ==}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      posthog-js: '>=1.257.2'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@posthog/types@1.372.6':
     resolution: {integrity: sha512-sqI36LBvuo8xcYsXIlVa0q3IXJJjqtatM2LrXlyOM7kgHrldBwS4ldzaTXrTdpe/TiIl1b4ZHxtSHMzPig+DnQ==}
+
+  '@posthog/types@1.376.4':
+    resolution: {integrity: sha512-EoDEvA925lf6yxPpbP4wozlXgu4b9WEqxZlFBUDd4k2akP5R/RWyHpvQT8aYyfY6BtSLn8TnVwxPQOM4b90isA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -6912,6 +6942,18 @@ packages:
   posthog-js@1.372.6:
     resolution: {integrity: sha512-+Fy9fwWni5WDKQXiUBIzFvdmnZSR6OBxGC/4wj09JvvK5JE4dhI9ZlKO1+b887PowjeAx0sx1Tf+S1eAjDvzqg==}
 
+  posthog-js@1.376.4:
+    resolution: {integrity: sha512-SGhZWMBpd9GyV1+Klhx/vRwyy/reRRpJGYc1n1rYG9+LAML/YUEIrfl3Y2CLvuwmhKbPVY5W98Z7pAVQ88Qf1A==}
+
+  posthog-node@5.35.6:
+    resolution: {integrity: sha512-LwoXnR89A0l75jvFrXjtsAs0BbpyCjnwY8YIUkZT91rt1YnIUfBYiLj7qoUYApdNgesgWQQHqLXxLYX59a6ZYw==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -7533,6 +7575,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -10784,7 +10829,36 @@ snapshots:
     dependencies:
       '@posthog/types': 1.372.6
 
+  '@posthog/core@1.29.13':
+    dependencies:
+      '@posthog/types': 1.376.4
+
+  '@posthog/next@0.4.67(@types/react@19.2.10)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.41))(next@16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@posthog/core': 1.29.13
+      '@posthog/react': 1.9.1(@types/react@19.2.10)(posthog-js@1.376.4)(react@19.2.4)
+      next: 16.2.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      posthog-js: 1.376.4
+      posthog-node: 5.35.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      server-only: 0.0.1
+    optionalDependencies:
+      '@vercel/functions': 3.6.0(@aws-sdk/credential-provider-web-identity@3.972.41)
+    transitivePeerDependencies:
+      - '@types/react'
+      - rxjs
+
+  '@posthog/react@1.9.1(@types/react@19.2.10)(posthog-js@1.376.4)(react@19.2.4)':
+    dependencies:
+      posthog-js: 1.376.4
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.10
+
   '@posthog/types@1.372.6': {}
+
+  '@posthog/types@1.376.4': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -15825,6 +15899,26 @@ snapshots:
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.2.0
 
+  posthog-js@1.376.4:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.208.0
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@posthog/core': 1.29.13
+      '@posthog/types': 1.376.4
+      core-js: 3.49.0
+      dompurify: 3.4.1
+      fflate: 0.4.8
+      preact: 10.29.1
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.2.0
+
+  posthog-node@5.35.6:
+    dependencies:
+      '@posthog/core': 1.29.13
+
   powershell-utils@0.1.0: {}
 
   preact@10.29.1: {}
@@ -16654,6 +16748,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  server-only@0.0.1: {}
 
   set-cookie-parser@3.1.0: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -74,7 +74,10 @@ export default function RootLayout({
           geistMono.variable,
         )}
       >
-        <PostHogProvider clientOptions={{ api_host: "/ingest" }} bootstrapFlags>
+        <PostHogProvider
+          apiKey={process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN}
+          clientOptions={{ api_host: "/ingest" }}
+        >
           <PostHogPageView />
           <NuqsAdapter>{children}</NuqsAdapter>
           <VercelAnalytics />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@heroui/react";
+import { PostHogPageView, PostHogProvider } from "@posthog/next";
 import { Analytics as VercelAnalytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
@@ -73,16 +74,19 @@ export default function RootLayout({
           geistMono.variable,
         )}
       >
-        <NuqsAdapter>{children}</NuqsAdapter>
-        <VercelAnalytics />
-        <SpeedInsights />
-        {/* Keep Umami during the PostHog 90-day production data warm-up. */}
-        <Script
-          defer
-          src="https://umami.ruchern.dev/script.js"
-          data-website-id="23a07b6c-093c-4831-840e-9d2998eba9e9"
-          data-domains="ruchern.dev"
-        />
+        <PostHogProvider clientOptions={{ api_host: "/ingest" }} bootstrapFlags>
+          <PostHogPageView />
+          <NuqsAdapter>{children}</NuqsAdapter>
+          <VercelAnalytics />
+          <SpeedInsights />
+          {/* Keep Umami during the PostHog 90-day production data warm-up. */}
+          <Script
+            defer
+            src="https://umami.ruchern.dev/script.js"
+            data-website-id="23a07b6c-093c-4831-840e-9d2998eba9e9"
+            data-domains="ruchern.dev"
+          />
+        </PostHogProvider>
       </body>
     </html>
   );

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,7 +1,0 @@
-import posthog from "posthog-js";
-
-posthog.init(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN as string, {
-  api_host: "/ingest",
-  ui_host: "https://eu.posthog.com",
-  defaults: "2026-01-30",
-});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,5 @@
 import { betterFetch } from "@better-fetch/fetch";
+import { postHogMiddleware } from "@posthog/next";
 import type { Session } from "better-auth/types";
 import { type NextRequest, NextResponse } from "next/server";
 import { ERROR_IDS } from "@/constants/error-ids";
@@ -16,6 +17,14 @@ import { logError } from "@/lib/logger";
  * @see {@link https://better-auth.com/docs/concepts/session Better Auth Sessions}
  */
 export const proxy = async (request: NextRequest) => {
+  // Public routes skip the auth check and only seed the PostHog identity cookie.
+  if (!request.nextUrl.pathname.startsWith("/studio")) {
+    return postHogMiddleware({
+      apiKey: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
+      proxy: true,
+    })(request);
+  }
+
   try {
     const { data: session, error } = await betterFetch<Session>(
       "/api/auth/get-session",
@@ -43,8 +52,11 @@ export const proxy = async (request: NextRequest) => {
       return NextResponse.redirect(new URL("/login", request.url));
     }
 
-    // Session valid, allow access
-    return NextResponse.next();
+    // Session valid, allow access and seed the PostHog identity cookie
+    return postHogMiddleware({
+      apiKey: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
+      proxy: true,
+    })(request);
   } catch (error) {
     // Unexpected error (network failure, timeout, etc.)
     logError(ERROR_IDS.AUTH_MIDDLEWARE_ERROR, error, {
@@ -56,5 +68,5 @@ export const proxy = async (request: NextRequest) => {
 };
 
 export const config = {
-  matcher: ["/studio/:path*"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)", "/studio/:path*"],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,7 +21,7 @@ export const proxy = async (request: NextRequest) => {
   if (!request.nextUrl.pathname.startsWith("/studio")) {
     return postHogMiddleware({
       apiKey: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
-      proxy: true,
+      proxy: { host: process.env.NEXT_PUBLIC_POSTHOG_HOST },
     })(request);
   }
 
@@ -55,7 +55,7 @@ export const proxy = async (request: NextRequest) => {
     // Session valid, allow access and seed the PostHog identity cookie
     return postHogMiddleware({
       apiKey: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
-      proxy: true,
+      proxy: { host: process.env.NEXT_PUBLIC_POSTHOG_HOST },
     })(request);
   } catch (error) {
     // Unexpected error (network failure, timeout, etc.)


### PR DESCRIPTION
- Replace manual posthog-js init (deleted `instrumentation-client.ts`) with the `@posthog/next` `PostHogProvider` in the root layout
- Fix the Next.js 16 `proxy.ts` entrypoint conflict: merge the Better Auth `/studio` guard and PostHog cookie seeding into a single `proxy` export, dropping the competing `export default`
- Gate the auth check to `/studio` so public routes skip it and only seed the identity cookie; matcher stays site-wide for analytics
- Pass `apiKey: NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` explicitly since the SDK otherwise reads `NEXT_PUBLIC_POSTHOG_KEY`, which this project does not set
