### PR TITLE
Pin GPT-5.6 pricing overrides for OpenAI

### DIFF
--- a/packages/usage/src/__tests__/pricing.test.ts
+++ b/packages/usage/src/__tests__/pricing.test.ts
@@ -2,12 +2,10 @@ import { buildPricing, type ModelsDevApi } from "../pricing";
 
 /**
  * Fixture mirroring the models.dev payload shape. `gpt-5.5` is priced under both
- * `openai` and `fireworks-ai` to prove provider selection. Note `gpt-5.5-fast`
- * is deliberately absent: it is the fast-tier model id that models.dev does not
- * list, so it resolves only via the hardcoded `PRIORITY_RATES` override (and
- * stays null under any other provider, proving the override is provider-scoped).
- * `claude-sonnet-5` is likewise deliberately absent: models.dev doesn't list it
- * yet, so it resolves only via the `PRIORITY_RATES` override.
+ * `openai` and `fireworks-ai` to prove provider selection. The GPT-5.6 entries
+ * deliberately carry incorrect rates so the tests prove the pinned OpenAI
+ * overrides take precedence. `gpt-5.5-fast` and `claude-sonnet-5` are absent,
+ * so they resolve only via provider-scoped overrides.
  */
 const api: ModelsDevApi = {
   anthropic: {
@@ -21,11 +19,16 @@ const api: ModelsDevApi = {
     models: {
       "gpt-5.5": { cost: { input: 1, output: 2 } },
       "gpt-5-codex": { cost: { input: 1.25, output: 10 } },
+      "gpt-5.6": { cost: { input: 91, output: 91 } },
+      "gpt-5.6-sol": { cost: { input: 92, output: 92 } },
+      "gpt-5.6-terra": { cost: { input: 93, output: 93 } },
+      "gpt-5.6-luna": { cost: { input: 94, output: 94 } },
     },
   },
   "fireworks-ai": {
     models: {
       "gpt-5.5": { cost: { input: 99, output: 99 } },
+      "gpt-5.6-sol": { cost: { input: 98, output: 98 } },
     },
   },
 };
@@ -67,6 +70,45 @@ describe("buildPricing", () => {
     expect(
       pricing.priceFor("gpt-5.5-fast", { provider: "fireworks-ai" }),
     ).toBeNull();
+  });
+
+  it("should pin exact GPT-5.6 rates ahead of models.dev", () => {
+    expect(pricing.priceFor("gpt-5.6", { provider: "openai" })).toEqual({
+      input: 5,
+      output: 30,
+      cacheRead: 0.5,
+      cacheWrite: 6.25,
+    });
+    expect(pricing.priceFor("gpt-5.6-sol", { provider: "openai" })).toEqual({
+      input: 5,
+      output: 30,
+      cacheRead: 0.5,
+      cacheWrite: 6.25,
+    });
+    expect(pricing.priceFor("gpt-5.6-terra", { provider: "openai" })).toEqual({
+      input: 2.5,
+      output: 15,
+      cacheRead: 0.25,
+      cacheWrite: 3.125,
+    });
+    expect(pricing.priceFor("gpt-5.6-luna", { provider: "openai" })).toEqual({
+      input: 1,
+      output: 6,
+      cacheRead: 0.1,
+      cacheWrite: 1.25,
+    });
+  });
+
+  it("should price the generic GPT-5.6 alias identically to Sol", () => {
+    expect(pricing.priceFor("gpt-5.6", { provider: "openai" })).toEqual(
+      pricing.priceFor("gpt-5.6-sol", { provider: "openai" }),
+    );
+  });
+
+  it("should scope GPT-5.6 overrides to the OpenAI provider", () => {
+    expect(
+      pricing.priceFor("gpt-5.6-sol", { provider: "fireworks-ai" }),
+    ).toEqual({ input: 98, output: 98, cacheRead: 0, cacheWrite: 0 });
   });
 
   it("should override claude-sonnet-5 with the priority rate (anthropic-scoped)", () => {
@@ -123,5 +165,23 @@ describe("buildPricing", () => {
       { provider: "openai" },
     );
     expect(cost).toBeCloseTo(88.75, 6);
+  });
+
+  it("should price every GPT-5.6 token bucket at its pinned rate", () => {
+    const cost = pricing.costOf(
+      {
+        input: 1_000_000,
+        output: 1_000_000,
+        cacheRead: 1_000_000,
+        cacheWrite: 1_000_000,
+        reasoning: 1_000_000,
+      },
+      "gpt-5.6-terra",
+      { provider: "openai" },
+    );
+
+    // $2.50 input + $15 output + $0.25 cache read + $3.125 cache write
+    // + $15 reasoning (billed as output) = $35.875.
+    expect(cost).toBeCloseTo(35.875, 6);
   });
 });

--- a/packages/usage/src/pricing.ts
+++ b/packages/usage/src/pricing.ts
@@ -36,18 +36,28 @@ export interface ModelRate {
   cacheWrite: number;
 }
 
+const GPT_5_6_SOL_RATE: ModelRate = {
+  input: 5,
+  output: 30,
+  cacheRead: 0.5,
+  cacheWrite: 6.25,
+};
+
 /**
- * Fast-tier model ids that no pricing DB lists. OpenCode logs OpenAI's fast
- * (priority) service tier as the distinct model id `gpt-5.5-fast` — the `-fast`
- * suffix is the tier signal — but models.dev, OpenRouter, and LiteLLM all either
- * omit it or price it wrongly, so it otherwise resolves to "N.A.". We override
- * with OpenAI's published priority rate (2.5x the standard `gpt-5.5` rate: input
- * $12.50/M, cached input $1.25/M, output $75/M). Plain `gpt-5.5` is the standard
- * tier and is deliberately NOT overridden — models.dev prices it correctly.
- * Keyed provider → model to mirror `byProvider`; returned ahead of the models.dev
- * lookup so the cost is baked straight into the stored `costUsd`.
+ * Provider-scoped rates that must remain stable even when a pricing database is
+ * stale or missing a model. Returned ahead of the models.dev lookup so the cost
+ * is baked straight into the stored `costUsd`.
+ *
+ * OpenCode logs OpenAI's fast (priority) service tier as the distinct model id
+ * `gpt-5.5-fast`, which pricing databases omit or price incorrectly. GPT-5.6 is
+ * pinned to OpenAI's published standard-context rates, including the 90% cache-
+ * read discount and cache writes at 1.25x uncached input. The generic `gpt-5.6`
+ * id is a Sol alias. Long-context and unpublished fast/pro variants are not
+ * inferred from aggregate logs.
+ *
+ * @see https://openai.com/index/previewing-gpt-5-6-sol/
  */
-const PRIORITY_RATES: Record<string, Record<string, ModelRate>> = {
+const MODEL_RATE_OVERRIDES: Record<string, Record<string, ModelRate>> = {
   anthropic: {
     // Standard (from 1 Sep 2026) pricing (docs: platform.claude.com/docs/en/about-claude/pricing).
     // models.dev doesn't list claude-sonnet-5 yet, so this covers it until that catches
@@ -62,6 +72,20 @@ const PRIORITY_RATES: Record<string, Record<string, ModelRate>> = {
   },
   openai: {
     "gpt-5.5-fast": { input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 0 },
+    "gpt-5.6": GPT_5_6_SOL_RATE,
+    "gpt-5.6-sol": GPT_5_6_SOL_RATE,
+    "gpt-5.6-terra": {
+      input: 2.5,
+      output: 15,
+      cacheRead: 0.25,
+      cacheWrite: 3.125,
+    },
+    "gpt-5.6-luna": {
+      input: 1,
+      output: 6,
+      cacheRead: 0.1,
+      cacheWrite: 1.25,
+    },
   },
 };
 
@@ -140,9 +164,9 @@ export function buildPricing(api: ModelsDevApi): Pricing {
     // Prefer an explicit provider (multi-provider agents), else derive from agent.
     const provider =
       opts?.provider ?? (agent ? AGENT_PROVIDERS[agent] : undefined);
-    // Always-priority models override the standard models.dev rate.
-    if (provider && PRIORITY_RATES[provider]?.[canonical]) {
-      return PRIORITY_RATES[provider][canonical];
+    // Provider-scoped overrides take precedence over models.dev.
+    if (provider && MODEL_RATE_OVERRIDES[provider]?.[canonical]) {
+      return MODEL_RATE_OVERRIDES[provider][canonical];
     }
     if (provider && byProvider[provider]?.[canonical]) {
       return byProvider[provider][canonical];


### PR DESCRIPTION
## Summary
- Pin OpenAI GPT-5.6 pricing ahead of models.dev so cost calculations stay stable when the upstream catalogue is stale or incorrect.
- Treat `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` as provider-scoped overrides, while leaving non-OpenAI providers to their normal pricing sources.
- Expand pricing tests to cover the pinned rates, alias behaviour, provider scoping, and full token-bucket cost calculation.

## Testing
- Added unit coverage for exact GPT-5.6 rates, alias equivalence, provider scoping, and reasoning/cache billing.
- Not run (not requested).