### PR TITLE
Add free model chip to usage breakdown

### DIFF
--- a/apps/web/src/app/(main)/usage/components/__tests__/free-model-chip.test.tsx
+++ b/apps/web/src/app/(main)/usage/components/__tests__/free-model-chip.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import type { Cost } from "@workspace/usage/types";
+import { FreeModelChip } from "../free-model-chip";
+
+function renderChip(viewId: string, cost: Cost) {
+  return render(<FreeModelChip cost={cost} viewId={viewId} />);
+}
+
+describe("FreeModelChip", () => {
+  it("should display Free for a model with an exact zero cost", () => {
+    renderChip("model", 0);
+
+    expect(screen.getByText("Free")).toBeInTheDocument();
+  });
+
+  it("should not display Free for positive or unpriced model costs", () => {
+    for (const cost of [0.001, null]) {
+      const view = renderChip("model", cost);
+
+      expect(screen.queryByText("Free")).not.toBeInTheDocument();
+      view.unmount();
+    }
+  });
+
+  it("should not display Free outside the model view", () => {
+    for (const viewId of ["provider", "agent"]) {
+      const view = renderChip(viewId, 0);
+
+      expect(screen.queryByText("Free")).not.toBeInTheDocument();
+      view.unmount();
+    }
+  });
+});

--- a/apps/web/src/app/(main)/usage/components/free-model-chip.tsx
+++ b/apps/web/src/app/(main)/usage/components/free-model-chip.tsx
@@ -1,0 +1,19 @@
+import { Chip } from "@heroui/react";
+import type { Cost } from "@workspace/usage/types";
+
+interface FreeModelChipProps {
+  cost: Cost;
+  viewId: string;
+}
+
+export function FreeModelChip({ cost, viewId }: FreeModelChipProps) {
+  if (viewId !== "model" || cost !== 0) {
+    return null;
+  }
+
+  return (
+    <Chip color="success" size="sm" variant="soft">
+      Free
+    </Chip>
+  );
+}

--- a/apps/web/src/app/(main)/usage/components/usage-breakdown.tsx
+++ b/apps/web/src/app/(main)/usage/components/usage-breakdown.tsx
@@ -30,6 +30,7 @@ import { providerLogoUrl } from "@workspace/usage/providers";
 import type { Cost, UsageBreakdownRow } from "@workspace/usage/types";
 import Image from "next/image";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { FreeModelChip } from "./free-model-chip";
 
 interface BreakdownView {
   id: string;
@@ -210,13 +211,14 @@ function getColumns({
       isRowHeader: true,
       allowsSorting: true,
       cell: (row) => (
-        <span className="inline-flex min-w-0 items-center gap-2">
+        <span className="inline-flex w-full min-w-0 items-center gap-2 pe-8 sm:pe-0">
           <RowVisual row={row} viewId={viewId} />
           <span className="truncate font-medium text-xs">
             {viewId === "provider"
               ? (providerDisplayNames[row.key] ?? row.key)
               : row.key}
           </span>
+          <FreeModelChip cost={row.cost} viewId={viewId} />
         </span>
       ),
       minWidth: 240,


### PR DESCRIPTION
## Summary
- Add a `Free` chip for zero-cost entries in the model usage breakdown.
- Keep the chip hidden for non-model views and for non-zero or unpriced costs.
- Add component tests covering the display and visibility rules.

## Testing
- Added unit tests for `FreeModelChip`.
- Not run (not requested).