### PR TITLE
Replace LiteLLM with AI Gateway and OpenRouter

### DIFF
--- a/apps/web/src/lib/queries/__tests__/models.test.ts
+++ b/apps/web/src/lib/queries/__tests__/models.test.ts
@@ -1,0 +1,119 @@
+import type { ModelEntry } from "@workspace/usage/registry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` factories are hoisted above module scope, so the spies they close
+// over have to be created with `vi.hoisted`.
+const { redisGet, redisSet, upsertModelRegistry } = vi.hoisted(() => ({
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+  upsertModelRegistry: vi.fn(),
+}));
+
+vi.mock("@/config/redis", () => ({
+  default: { get: redisGet, set: redisSet },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logWarning: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+// No curated overrides in the DB for these tests; the seed overrides still merge.
+vi.mock("@/schema", () => ({
+  db: { select: () => ({ from: () => ({ where: async () => [] }) }) },
+  model: {},
+  // `models.ts` pulls in the reprice helper, which reaches for this table.
+  tokenUsage: {},
+}));
+
+vi.mock("@/lib/queries/model-registry", () => ({
+  rowToEntry: (row: unknown) => row,
+  upsertModelRegistry,
+}));
+
+import { syncModelRegistry } from "../models";
+
+const gatewayPayload = {
+  data: [
+    {
+      id: "openai/gpt-5-codex",
+      name: "GPT-5-Codex",
+      pricing: { input: "0.00000125", output: "0.00001" },
+    },
+  ],
+};
+
+/** The entries handed to the upsert, i.e. what the merge actually produced. */
+function upsertedEntries(): ModelEntry[] {
+  return upsertModelRegistry.mock.calls[0]?.[0] ?? [];
+}
+
+describe("syncModelRegistry source fetching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisSet.mockResolvedValue("OK");
+    upsertModelRegistry.mockResolvedValue(0);
+  });
+
+  it("should still reach the source when Redis is unavailable", async () => {
+    // Regression: an unconfigured or unreachable Redis used to propagate out of
+    // the cache read and discard the entire source, even though the HTTP fetch
+    // below would have succeeded. On a local ingest with no Redis credentials
+    // that took AI Gateway and OpenRouter out together, and every Codex model
+    // lost pricing because Gateway is their only source.
+    redisGet.mockRejectedValue(new Error("Redis client was not initialized"));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => gatewayPayload,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncModelRegistry();
+
+    expect(fetchMock).toHaveBeenCalled();
+    const codex = upsertedEntries().find(
+      (e) => e.provider === "openai" && e.id === "gpt-5-codex",
+    );
+    expect(codex?.rate).toMatchObject({ input: 1.25, output: 10 });
+  });
+
+  it("should serve from cache without fetching when Redis has a payload", async () => {
+    redisGet.mockResolvedValue(gatewayPayload);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncModelRegistry();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(upsertedEntries().some((e) => e.id === "gpt-5-codex")).toBe(true);
+  });
+
+  it("should narrow the merge, not fail, when a source is down", async () => {
+    redisGet.mockResolvedValue(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    );
+
+    await expect(syncModelRegistry()).resolves.toBeDefined();
+    // Every live source failed, so only the seed overrides survive.
+    expect(upsertedEntries().every((e) => e.isOverride)).toBe(true);
+  });
+
+  it("should not fail a source when writing the cache back fails", async () => {
+    redisGet.mockResolvedValue(null);
+    redisSet.mockRejectedValue(new Error("Redis unavailable"));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => gatewayPayload,
+      }),
+    );
+
+    await syncModelRegistry();
+
+    expect(upsertedEntries().some((e) => e.id === "gpt-5-codex")).toBe(true);
+  });
+});

--- a/apps/web/src/lib/queries/models.ts
+++ b/apps/web/src/lib/queries/models.ts
@@ -3,11 +3,14 @@ import {
   type Pricing,
 } from "@workspace/usage/pricing";
 import {
+  type GatewayApi,
   type ModelEntry,
   type ModelsDevApi,
   mergeRegistry,
-  normaliseLiteLLM,
+  normaliseAIGateway,
   normaliseModelsDev,
+  normaliseOpenRouter,
+  type OpenRouterApi,
   SEED_OVERRIDES,
 } from "@workspace/usage/registry";
 import { eq, inArray } from "drizzle-orm";
@@ -19,10 +22,18 @@ import { repriceUnpricedTokenUsage } from "@/lib/queries/usage";
 import { db, model } from "@/schema";
 
 const MODELS_API_URL = "https://models.dev/api.json";
-const LITELLM_URL =
-  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+/**
+ * The Gateway catalogue is public: an unauthenticated GET returns it, while an
+ * *invalid* bearer is rejected with 401. So this is deliberately sent with no
+ * Authorization header — supplying a stale token could only turn a working
+ * request into a failing one, and the public catalogue carries everything the
+ * registry needs (list prices plus names, release dates and context windows).
+ */
+const GATEWAY_URL = "https://ai-gateway.vercel.sh/v1/models";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/models";
 const MODELS_PRICING_CACHE_KEY = "models:pricing";
-const LITELLM_CACHE_KEY = "models:litellm";
+const GATEWAY_CACHE_KEY = "models:gateway";
+const OPENROUTER_CACHE_KEY = "models:openrouter";
 const SOURCE_CACHE_TTL = 86_400;
 
 const PROVIDER_ALIASES: Record<string, string> = {
@@ -69,17 +80,20 @@ export async function loadPricing(): Promise<Pricing> {
 /**
  * Refresh the `model` registry from all sources and return the built pricing.
  *
- * Fetches LiteLLM (primary rates) and models.dev (names/metadata + rate
- * gap-fill) alongside the curated DB overrides, merges them by precedence
- * (override > LiteLLM > models.dev for rates; override > models.dev for names),
+ * Fetches AI Gateway (zero-markup vendor list rates, plus names and release
+ * dates), OpenRouter (a small tail of vendor-internal slugs), and models.dev
+ * (the only source covering reseller-routed providers such as OpenCode, which
+ * bill at the reseller's rate) alongside the curated DB overrides. Merges by
+ * precedence — override > Gateway > OpenRouter > models.dev for rates —
  * upserts the merged rows, and returns pricing built from them. A source that
- * fails to fetch is skipped, not fatal — the merge omits that layer and the
+ * fails to fetch is skipped, not fatal: the merge omits that layer and the
  * existing table rows survive as the last-good snapshot. Runs at the top of
  * each ingest.
  */
 export async function syncModelRegistry(): Promise<Pricing> {
-  const [litellm, modelsDev, overrides] = await Promise.all([
-    fetchLiteLLMEntries(),
+  const [gateway, openrouter, modelsDev, overrides] = await Promise.all([
+    fetchGatewayEntries(),
+    fetchOpenRouterEntries(),
     fetchModelsDevEntries(),
     loadOverrideEntries(),
   ]);
@@ -87,7 +101,12 @@ export async function syncModelRegistry(): Promise<Pricing> {
   // Seed overrides bootstrap keys the DB has no curated override for yet.
   const seeded = seedOverrides(overrides);
 
-  const merged = mergeRegistry({ overrides: seeded, litellm, modelsDev });
+  const merged = mergeRegistry({
+    overrides: seeded,
+    gateway,
+    openrouter,
+    modelsDev,
+  });
   await upsertModelRegistry(merged);
   return buildPricingFromRegistry(merged);
 }
@@ -101,26 +120,57 @@ function seedOverrides(dbOverrides: ModelEntry[]): ModelEntry[] {
   return [...dbOverrides, ...missing];
 }
 
-async function fetchLiteLLMEntries(): Promise<ModelEntry[]> {
+/**
+ * Fetch one JSON source through the Redis day-cache, normalise it, and degrade
+ * to an empty layer on failure. An unavailable source must narrow the merge,
+ * never fail the whole sync — the other layers plus the persisted table still
+ * produce usable pricing.
+ */
+async function fetchSourceEntries<T>(
+  label: string,
+  url: string,
+  cacheKey: string,
+  normalise: (json: T) => ModelEntry[],
+): Promise<ModelEntry[]> {
   try {
-    const cached = await redis.get<Record<string, unknown>>(LITELLM_CACHE_KEY);
-    if (cached) return normaliseLiteLLM(cached);
+    const cached = await redis.get<T>(cacheKey);
+    if (cached) return normalise(cached);
 
-    const response = await fetch(LITELLM_URL);
-    if (!response.ok) throw new Error(`LiteLLM returned ${response.status}`);
-    const json = (await response.json()) as Record<string, unknown>;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`${label} returned ${response.status}`);
+    }
+    const json = (await response.json()) as T;
     try {
-      await redis.set(LITELLM_CACHE_KEY, json, { ex: SOURCE_CACHE_TTL });
+      await redis.set(cacheKey, json, { ex: SOURCE_CACHE_TTL });
     } catch {
       // Pricing can still be built from the fresh response if Redis is down.
     }
-    return normaliseLiteLLM(json);
+    return normalise(json);
   } catch (error) {
-    logWarning("Skipped LiteLLM source during model registry sync", {
+    logWarning(`Skipped ${label} source during model registry sync`, {
       error: error instanceof Error ? error.message : String(error),
     });
     return [];
   }
+}
+
+function fetchGatewayEntries(): Promise<ModelEntry[]> {
+  return fetchSourceEntries<GatewayApi>(
+    "AI Gateway",
+    GATEWAY_URL,
+    GATEWAY_CACHE_KEY,
+    normaliseAIGateway,
+  );
+}
+
+function fetchOpenRouterEntries(): Promise<ModelEntry[]> {
+  return fetchSourceEntries<OpenRouterApi>(
+    "OpenRouter",
+    OPENROUTER_URL,
+    OPENROUTER_CACHE_KEY,
+    normaliseOpenRouter,
+  );
 }
 
 async function fetchModelsDevEntries(): Promise<ModelEntry[]> {

--- a/apps/web/src/lib/queries/models.ts
+++ b/apps/web/src/lib/queries/models.ts
@@ -133,7 +133,12 @@ async function fetchSourceEntries<T>(
   normalise: (json: T) => ModelEntry[],
 ): Promise<ModelEntry[]> {
   try {
-    const cached = await redis.get<T>(cacheKey);
+    // Read the cache in its own guard. Folding it into the outer try would let
+    // an unreachable or unconfigured Redis discard the source entirely, even
+    // though the HTTP fetch below would have succeeded — which is exactly what
+    // happened on a local ingest run with no Redis credentials: every Codex
+    // model lost pricing because AI Gateway is its only source.
+    const cached = await readCache<T>(cacheKey);
     if (cached) return normalise(cached);
 
     const response = await fetch(url);
@@ -286,12 +291,21 @@ async function fetchModelsApi(): Promise<ModelsApi> {
   return (await response.json()) as ModelsApi;
 }
 
-async function getCachedPricingApi(): Promise<ModelsDevApi | null> {
+/**
+ * Read a cached source payload, treating any Redis failure as a cache miss.
+ * The cache is an optimisation, never a dependency: a miss costs one HTTP
+ * fetch, whereas an error propagating out of the caller costs the whole source.
+ */
+async function readCache<T>(cacheKey: string): Promise<T | null> {
   try {
-    return await redis.get<ModelsDevApi>(MODELS_PRICING_CACHE_KEY);
+    return await redis.get<T>(cacheKey);
   } catch {
     return null;
   }
+}
+
+function getCachedPricingApi(): Promise<ModelsDevApi | null> {
+  return readCache<ModelsDevApi>(MODELS_PRICING_CACHE_KEY);
 }
 
 async function cachePricingApi(api: ModelsDevApi): Promise<void> {

--- a/apps/web/src/schema/model.ts
+++ b/apps/web/src/schema/model.ts
@@ -43,7 +43,9 @@ export const model = pgTable(
     contextLimit: integer(),
     releaseDate: date(),
     source: text({
-      enum: ["models.dev", "litellm", "openrouter", "override"],
+      // `litellm` is retained so rows written before that source was retired
+      // still read back cleanly; the next sync rewrites them.
+      enum: ["models.dev", "gateway", "openrouter", "litellm", "override"],
     }).notNull(),
     isOverride: boolean().notNull().default(false),
     aliasTarget: text(),

--- a/packages/usage/src/__tests__/pricing.test.ts
+++ b/packages/usage/src/__tests__/pricing.test.ts
@@ -40,10 +40,11 @@ const api: ModelsDevApi = {
   },
 };
 
-// Mirrors production: overrides > LiteLLM > models.dev, built into the registry.
+// Mirrors production: overrides > Gateway > OpenRouter > models.dev.
 const registry = mergeRegistry({
   overrides: SEED_OVERRIDES,
-  litellm: [],
+  gateway: [],
+  openrouter: [],
   modelsDev: normaliseModelsDev(api),
 });
 

--- a/packages/usage/src/__tests__/registry.test.ts
+++ b/packages/usage/src/__tests__/registry.test.ts
@@ -95,6 +95,51 @@ describe("normaliseAIGateway", () => {
   it("should skip entries with no owner prefix", () => {
     expect(normaliseAIGateway({ data: [{ id: "bare-model" }] })).toEqual([]);
   });
+
+  it("should drop malformed prices rather than storing NaN", () => {
+    // Postgres `numeric` accepts 'NaN', so an unguarded NaN would persist and
+    // silently poison every cost computed from it.
+    const [entry] = normaliseAIGateway({
+      data: [
+        {
+          id: "openai/broken",
+          pricing: { input: "n/a", output: "0.00001" },
+        },
+      ],
+    });
+    expect(entry.rate).toBeUndefined();
+  });
+
+  it("should treat an empty price string as unknown, not free", () => {
+    const [entry] = normaliseAIGateway({
+      data: [{ id: "openai/blank", pricing: { input: "", output: "" } }],
+    });
+    expect(entry.rate).toBeUndefined();
+  });
+
+  it("should keep a genuine zero price", () => {
+    const [entry] = normaliseAIGateway({
+      data: [{ id: "openai/free", pricing: { input: "0", output: "0" } }],
+    });
+    expect(entry.rate).toMatchObject({ input: 0, output: 0 });
+  });
+
+  it("should survive an out-of-range release timestamp", () => {
+    // `toISOString()` throws a RangeError on an invalid date; letting it escape
+    // would take the whole source down, not just this entry.
+    const entries = normaliseAIGateway({
+      data: [
+        {
+          id: "openai/bad-date",
+          released: Number.MAX_SAFE_INTEGER,
+          pricing: { input: "0.000001", output: "0.000002" },
+        },
+      ],
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].releaseDate).toBeUndefined();
+    expect(entries[0].rate).toMatchObject({ input: 1, output: 2 });
+  });
 });
 
 describe("normaliseOpenRouter", () => {

--- a/packages/usage/src/__tests__/registry.test.ts
+++ b/packages/usage/src/__tests__/registry.test.ts
@@ -1,9 +1,10 @@
 import {
-  bareSlug,
+  canonicalSlug,
   type ModelEntry,
   mergeRegistry,
-  normaliseLiteLLM,
+  normaliseAIGateway,
   normaliseModelsDev,
+  normaliseOpenRouter,
 } from "../registry";
 
 describe("normaliseModelsDev", () => {
@@ -32,111 +33,158 @@ describe("normaliseModelsDev", () => {
   });
 });
 
-describe("bareSlug", () => {
-  it("should strip routing and vendor prefixes but keep dotted model names", () => {
-    expect(bareSlug("bedrock/anthropic.claude-sonnet-5")).toBe(
-      "claude-sonnet-5",
+describe("canonicalSlug", () => {
+  it("should collapse the punctuation differences between sources", () => {
+    // AI Gateway documents dots for versions; the Anthropic API and our logs
+    // use dashes, and logs additionally carry a dated variant.
+    expect(canonicalSlug("claude-opus-4.8")).toBe(
+      canonicalSlug("claude-opus-4-8"),
     );
-    expect(bareSlug("anthropic.claude-sonnet-5")).toBe("claude-sonnet-5");
-    expect(bareSlug("openai/gpt-5.6")).toBe("gpt-5.6");
-    // A dot inside the model name (not a vendor prefix) must survive.
-    expect(bareSlug("gpt-5.6")).toBe("gpt-5.6");
-    expect(bareSlug("claude-3.5-sonnet")).toBe("claude-3.5-sonnet");
+    expect(canonicalSlug("claude-haiku-4-5-20251001")).toBe(
+      canonicalSlug("claude-haiku-4.5"),
+    );
+  });
+
+  it("should keep genuinely different models apart", () => {
+    expect(canonicalSlug("gpt-5.6-sol")).not.toBe(
+      canonicalSlug("gpt-5.6-sol-fast"),
+    );
+    expect(canonicalSlug("claude-opus-4-8")).not.toBe(
+      canonicalSlug("claude-opus-5"),
+    );
   });
 });
 
-describe("normaliseLiteLLM", () => {
-  it("should convert per-token cost to USD/1M and infer the vendor from the slug", () => {
-    const entries = normaliseLiteLLM({
-      sample_spec: { input_cost_per_token: 0 },
-      "claude-sonnet-5": {
-        input_cost_per_token: 0.000_003,
-        output_cost_per_token: 0.000_015,
-        cache_read_input_token_cost: 0.000_000_3,
-        cache_creation_input_token_cost: 0.000_003_75,
-        max_input_tokens: 1_000_000,
-        litellm_provider: "anthropic",
-      },
-    });
-    expect(entries).toEqual([
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-5",
-        rate: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-        contextLimit: 1_000_000,
-        source: "litellm",
-      },
-    ]);
-  });
-
-  it("should dedupe a model across bedrock/vertex duplicates, first priced wins", () => {
-    const entries = normaliseLiteLLM({
-      "claude-sonnet-5": {
-        input_cost_per_token: 0.000_003,
-        output_cost_per_token: 0.000_015,
-        litellm_provider: "anthropic",
-      },
-      "bedrock/anthropic.claude-sonnet-5": {
-        input_cost_per_token: 0.000_009,
-        output_cost_per_token: 0.000_045,
-        litellm_provider: "bedrock_converse",
-      },
-    });
-    expect(entries).toHaveLength(1);
-    expect(entries[0]).toMatchObject({
-      provider: "anthropic",
-      id: "claude-sonnet-5",
-      rate: { input: 3, output: 15 },
-    });
-  });
-
-  it("should skip entries missing input or output cost", () => {
-    expect(
-      normaliseLiteLLM({
-        "embedding-model": {
-          input_cost_per_token: 0.000_001,
-          litellm_provider: "openai",
-          mode: "embedding",
+describe("normaliseAIGateway", () => {
+  it("should split owner/model, convert per-token pricing, and derive the release date", () => {
+    const [entry] = normaliseAIGateway({
+      data: [
+        {
+          id: "anthropic/claude-opus-4.8",
+          name: "Claude Opus 4.8",
+          released: 1_764_547_200,
+          context_window: 200_000,
+          pricing: {
+            input: "0.000005",
+            output: "0.000025",
+            input_cache_read: "0.0000005",
+            input_cache_write: "0.00000625",
+          },
         },
-      }),
-    ).toEqual([]);
+      ],
+    });
+    expect(entry).toMatchObject({
+      provider: "anthropic",
+      id: "claude-opus-4.8",
+      displayName: "Claude Opus 4.8",
+      contextLimit: 200_000,
+      rate: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+      source: "gateway",
+    });
+    expect(entry.releaseDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("should keep an unpriced model as a metadata-only entry", () => {
+    const [entry] = normaliseAIGateway({
+      data: [{ id: "openai/text-embedding-3", name: "Embedding" }],
+    });
+    expect(entry.displayName).toBe("Embedding");
+    expect(entry.rate).toBeUndefined();
+  });
+
+  it("should skip entries with no owner prefix", () => {
+    expect(normaliseAIGateway({ data: [{ id: "bare-model" }] })).toEqual([]);
+  });
+});
+
+describe("normaliseOpenRouter", () => {
+  it("should split the id and convert per-token pricing", () => {
+    const [entry] = normaliseOpenRouter({
+      data: [
+        {
+          id: "openai/gpt-5.6-terra-pro",
+          name: "GPT-5.6 Terra Pro",
+          created: 1_782_843_083,
+          context_length: 400_000,
+          pricing: {
+            prompt: "0.0000025",
+            completion: "0.000015",
+            input_cache_read: "0.00000025",
+          },
+        },
+      ],
+    });
+    expect(entry).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.6-terra-pro",
+      displayName: "GPT-5.6 Terra Pro",
+      contextLimit: 400_000,
+      rate: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+      source: "openrouter",
+    });
   });
 });
 
 describe("mergeRegistry", () => {
-  const litellm: ModelEntry[] = [
+  const gateway: ModelEntry[] = [
     {
       provider: "anthropic",
       id: "claude-sonnet-5",
+      displayName: "Claude Sonnet 5",
       rate: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-      source: "litellm",
+      source: "gateway",
+    },
+  ];
+  const openrouter: ModelEntry[] = [
+    {
+      provider: "anthropic",
+      id: "claude-sonnet-5",
+      displayName: "Anthropic: Claude Sonnet 5",
+      rate: { input: 50, output: 50 },
+      source: "openrouter",
     },
   ];
   const modelsDev: ModelEntry[] = [
     {
       provider: "anthropic",
       id: "claude-sonnet-5",
-      displayName: "Claude Sonnet 5",
+      displayName: "Claude Sonnet 5 (models.dev)",
       releaseDate: "2026-06-30",
       rate: { input: 99, output: 99 },
       source: "models.dev",
     },
   ];
 
-  it("should take the rate from LiteLLM over models.dev but the name from models.dev", () => {
-    const [entry] = mergeRegistry({ overrides: [], litellm, modelsDev });
+  it("should take the rate from Gateway ahead of OpenRouter and models.dev", () => {
+    const [entry] = mergeRegistry({
+      overrides: [],
+      gateway,
+      openrouter,
+      modelsDev,
+    });
     expect(entry).toMatchObject({
       provider: "anthropic",
       id: "claude-sonnet-5",
       displayName: "Claude Sonnet 5",
       releaseDate: "2026-06-30",
       rate: { input: 3, output: 15 },
-      source: "litellm",
+      source: "gateway",
       isOverride: false,
     });
   });
 
-  it("should let a rate-only override win the rate while keeping the models.dev name", () => {
+  it("should fall back to OpenRouter when Gateway lacks the model", () => {
+    const [entry] = mergeRegistry({
+      overrides: [],
+      gateway: [],
+      openrouter,
+      modelsDev,
+    });
+    expect(entry.rate).toMatchObject({ input: 50, output: 50 });
+    expect(entry.source).toBe("openrouter");
+  });
+
+  it("should let a rate-only override win while keeping the Gateway name", () => {
     const overrides: ModelEntry[] = [
       {
         provider: "anthropic",
@@ -146,7 +194,12 @@ describe("mergeRegistry", () => {
         isOverride: true,
       },
     ];
-    const [entry] = mergeRegistry({ overrides, litellm, modelsDev });
+    const [entry] = mergeRegistry({
+      overrides,
+      gateway,
+      openrouter,
+      modelsDev,
+    });
     expect(entry.rate).toEqual({
       input: 2,
       output: 10,
@@ -158,7 +211,7 @@ describe("mergeRegistry", () => {
     expect(entry.source).toBe("override");
   });
 
-  it("should let a name-only override keep the LiteLLM rate", () => {
+  it("should let a name-only override keep the Gateway rate", () => {
     const overrides: ModelEntry[] = [
       {
         provider: "anthropic",
@@ -168,7 +221,12 @@ describe("mergeRegistry", () => {
         isOverride: true,
       },
     ];
-    const [entry] = mergeRegistry({ overrides, litellm, modelsDev });
+    const [entry] = mergeRegistry({
+      overrides,
+      gateway,
+      openrouter,
+      modelsDev,
+    });
     expect(entry.displayName).toBe("My Sonnet");
     expect(entry.rate).toEqual({
       input: 3,
@@ -178,31 +236,45 @@ describe("mergeRegistry", () => {
     });
   });
 
-  it("should price a LiteLLM-only model models.dev is missing, and name a models.dev-only model", () => {
+  it("should union models unique to any single source", () => {
     const merged = mergeRegistry({
       overrides: [],
-      litellm: [
+      gateway: [
         {
           provider: "openai",
-          id: "gpt-new",
+          id: "gpt-gw",
           rate: { input: 1, output: 2 },
-          source: "litellm",
+          source: "gateway",
+        },
+      ],
+      openrouter: [
+        {
+          provider: "openai",
+          id: "gpt-or",
+          rate: { input: 3, output: 4 },
+          source: "openrouter",
         },
       ],
       modelsDev: [
         {
-          provider: "openai",
-          id: "gpt-old",
-          displayName: "GPT Old",
+          provider: "opencode-go",
+          id: "glm-5.2",
+          displayName: "GLM-5.2",
+          rate: { input: 1.4, output: 4.4 },
           source: "models.dev",
         },
       ],
     });
-    const gptNew = merged.find((e) => e.id === "gpt-new");
-    const gptOld = merged.find((e) => e.id === "gpt-old");
-    expect(gptNew?.rate).toEqual({ input: 1, output: 2 });
-    expect(gptOld?.displayName).toBe("GPT Old");
-    expect(gptOld?.rate).toBeUndefined();
+    expect(merged).toHaveLength(3);
+    // models.dev is the only source carrying reseller-routed providers.
+    expect(merged.find((e) => e.provider === "opencode-go")?.rate).toEqual({
+      input: 1.4,
+      output: 4.4,
+    });
+    expect(merged.find((e) => e.id === "gpt-or")?.rate).toEqual({
+      input: 3,
+      output: 4,
+    });
   });
 
   it("should carry an alias-only override with no rate", () => {
@@ -216,7 +288,8 @@ describe("mergeRegistry", () => {
           isOverride: true,
         },
       ],
-      litellm: [],
+      gateway: [],
+      openrouter: [],
       modelsDev: [],
     });
     expect(merged[0]).toMatchObject({

--- a/packages/usage/src/pricing.ts
+++ b/packages/usage/src/pricing.ts
@@ -1,13 +1,13 @@
 import { AGENT_PROVIDERS } from "./providers";
-import type { ModelEntry } from "./registry";
+import { canonicalSlug, type ModelEntry } from "./registry";
 import type { TokenBreakdown } from "./types";
 
 /**
- * Model pricing, built from the merged {@link ModelEntry} registry (LiteLLM +
- * models.dev + curated DB overrides). Formerly this module embedded pricing
- * gap-fillers as hardcoded constants; they now live as data in the `model`
- * table (bootstrapped from seed override rows and editable via the MCP tools),
- * so a newly-released model prices automatically once a live source lists it.
+ * Model pricing, built from the merged {@link ModelEntry} registry (AI Gateway +
+ * models.dev + OpenRouter + curated DB overrides). Formerly this module embedded
+ * pricing gap-fillers as hardcoded constants; they now live as data in the
+ * `model` table (bootstrapped from seed override rows and editable via the MCP
+ * tools), so a newly-released model prices automatically once a source lists it.
  *
  * Every lookup is provider-scoped: the provider is given explicitly
  * (multi-provider agents like OpenCode) or derived from the agent (Claude →
@@ -60,8 +60,11 @@ function toRate(rate: Partial<ModelRate>): ModelRate | null {
  */
 export function buildPricingFromRegistry(entries: ModelEntry[]): Pricing {
   // Per-provider lookup, plus per-provider aliases (e.g. codex-auto-review →
-  // gpt-5-codex).
+  // gpt-5-codex). A parallel index keyed by `canonicalSlug` absorbs the
+  // punctuation differences between sources (AI Gateway's `claude-opus-4.8` vs
+  // the logs' `claude-opus-4-8`); it is only consulted when the exact id misses.
   const byProvider: Record<string, Record<string, ModelRate>> = {};
+  const byProviderCanonical: Record<string, Record<string, ModelRate>> = {};
   const aliasByProvider: Record<string, Record<string, string>> = {};
 
   for (const entry of entries) {
@@ -74,6 +77,9 @@ export function buildPricingFromRegistry(entries: ModelEntry[]): Pricing {
     if (!rate) continue;
     byProvider[entry.provider] ??= {};
     byProvider[entry.provider][entry.id] = rate;
+    byProviderCanonical[entry.provider] ??= {};
+    // First entry wins, so an exact-id duplicate never displaces an earlier one.
+    byProviderCanonical[entry.provider][canonicalSlug(entry.id)] ??= rate;
   }
 
   const warned = new Set<string>();
@@ -85,8 +91,12 @@ export function buildPricingFromRegistry(entries: ModelEntry[]): Pricing {
       opts?.provider ?? (agent ? AGENT_PROVIDERS[agent] : undefined);
     if (!provider) return null;
     // Resolve a provider-scoped alias (replaces the old agent-keyed MODEL_ALIASES).
-    const canonical = aliasByProvider[provider]?.[model] ?? model;
-    return byProvider[provider]?.[canonical] ?? null;
+    const target = aliasByProvider[provider]?.[model] ?? model;
+    return (
+      byProvider[provider]?.[target] ??
+      byProviderCanonical[provider]?.[canonicalSlug(target)] ??
+      null
+    );
   }
 
   function costOf(

--- a/packages/usage/src/registry.ts
+++ b/packages/usage/src/registry.ts
@@ -3,22 +3,32 @@ import type { ModelRate } from "./pricing";
 /**
  * Pure, network-free model-registry layer.
  *
- * Each pricing/metadata source (LiteLLM, models.dev, or a curated DB override)
- * is normalised into a common {@link ModelEntry}, then merged by precedence
- * into the rows that back the `model` table and, in turn, pricing.
+ * Each pricing/metadata source (Vercel AI Gateway, models.dev, OpenRouter, or a
+ * curated DB override) is normalised into a common {@link ModelEntry}, then
+ * merged by precedence into the rows that back the `model` table and, in turn,
+ * pricing.
  *
  * Precedence, applied field-by-field:
- *   - rates:                override > LiteLLM > models.dev
- *   - names / release date / context limit: override > models.dev
+ *   - rates:                override > Gateway > OpenRouter > models.dev
+ *   - names / metadata:     override > Gateway > models.dev > OpenRouter
  *
- * LiteLLM has the broadest, freshest pricing but no display names, so it leads
- * on rates; models.dev supplies the names/release dates LiteLLM lacks and fills
- * any model LiteLLM misses. A curated override always wins. All of this is
- * pure so it can be unit-tested with fixtures — fetching + DB I/O live in
- * `apps/web/src/lib/queries`.
+ * The layers are complements, not competitors. Gateway is documented zero-markup
+ * (vendor list price) and carries names, release dates and cache rates for the
+ * first-party vendors. models.dev is the only source covering reseller-routed
+ * providers such as OpenCode and Ollama Cloud, which bill at the reseller's rate
+ * rather than the vendor's — so it can never be replaced by a vendor source.
+ * OpenRouter fills a small tail of vendor-internal slugs neither of the others
+ * lists. A curated override always wins. All of this is pure so it can be
+ * unit-tested with fixtures — fetching + DB I/O live in `apps/web/src/lib/queries`.
  */
 
-export type ModelSource = "models.dev" | "litellm" | "openrouter" | "override";
+/** `litellm` is retained for rows written before that source was retired. */
+export type ModelSource =
+  | "models.dev"
+  | "gateway"
+  | "openrouter"
+  | "litellm"
+  | "override";
 
 /**
  * Bootstrap override rows, replacing the former hardcoded `MODEL_RATE_OVERRIDES`
@@ -151,128 +161,143 @@ export function normaliseModelsDev(api: ModelsDevApi): ModelEntry[] {
   return entries;
 }
 
-// --- LiteLLM ---------------------------------------------------------------
-
-interface LiteLLMModel {
-  input_cost_per_token?: number;
-  output_cost_per_token?: number;
-  cache_read_input_token_cost?: number;
-  cache_creation_input_token_cost?: number;
-  max_input_tokens?: number;
-  litellm_provider?: string;
-  mode?: string;
-}
-export type LiteLLMTable = Record<string, LiteLLMModel | unknown>;
-
-/** Routing/hosting prefixes to strip, and vendor `<name>.` prefixes to unwrap. */
-const KNOWN_VENDOR_PREFIXES = new Set([
-  "anthropic",
-  "openai",
-  "azure",
-  "azure_ai",
-  "gemini",
-  "google",
-  "vertex_ai",
-  "bedrock",
-  "bedrock_converse",
-  "fireworks_ai",
-  "cohere",
-  "mistral",
-  "meta",
-  "xai",
-]);
-
-const LITELLM_PROVIDER_MAP: Record<string, string> = {
-  anthropic: "anthropic",
-  openai: "openai",
-  "text-completion-openai": "openai",
-  azure: "openai",
-  azure_ai: "openai",
-  gemini: "google",
-  google: "google",
-  vertex_ai: "google",
-  "vertex_ai-language-models": "google",
-  fireworks_ai: "fireworks-ai",
-  "fireworks-ai": "fireworks-ai",
-  xai: "xai",
-};
+// --- Slug canonicalisation --------------------------------------------------
 
 /**
- * Reduce a (possibly provider-prefixed / hosting-routed) LiteLLM key to the
- * bare model slug our logs use. Strips a leading `route/` segment, then a
- * leading vendor `<name>.` prefix — but only when `<name>` is a known vendor,
- * so a model whose slug legitimately contains a dot (e.g. `gpt-5.6`,
- * `claude-3.5-sonnet`) is left intact.
+ * Reduce a model slug to a comparison key.
+ *
+ * Sources disagree on punctuation for the same model. Vercel AI Gateway
+ * documents dots for version numbers (`claude-opus-4.8`) while the Anthropic
+ * API — and therefore our agent logs — use dashes (`claude-opus-4-8`), and logs
+ * additionally carry a dated variant (`claude-haiku-4-5-20251001`). Stripping
+ * the date suffix and all punctuation makes those three forms one key.
+ *
+ * Only ever used as a *fallback* after an exact id match, so a hypothetical
+ * collision between two genuinely different slugs cannot displace an exact hit.
  */
-export function bareSlug(key: string): string {
-  let slug = key.includes("/") ? key.slice(key.lastIndexOf("/") + 1) : key;
-  const dot = slug.indexOf(".");
-  if (dot > 0 && KNOWN_VENDOR_PREFIXES.has(slug.slice(0, dot).toLowerCase())) {
-    slug = slug.slice(dot + 1);
-  }
-  return slug;
+export function canonicalSlug(slug: string): string {
+  return slug
+    .replace(/-\d{8}$/, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
 }
 
-/** Infer the billing vendor from the slug itself for the models we track. */
-function vendorFromSlug(slug: string): string | undefined {
-  const s = slug.toLowerCase();
-  if (s.startsWith("claude")) return "anthropic";
-  if (
-    s.startsWith("gpt") ||
-    s.startsWith("codex") ||
-    s.startsWith("chatgpt") ||
-    /^o[134]\b/.test(s)
-  ) {
-    return "openai";
-  }
-  if (s.startsWith("gemini")) return "google";
-  return undefined;
+/** Prices arrive as per-token decimal strings; the registry stores USD/1M. */
+const perTokenStr = (v?: string): number | undefined =>
+  v == null ? undefined : Number(v) * 1_000_000;
+
+const isoDay = (unixSeconds?: number): string | undefined =>
+  unixSeconds == null
+    ? undefined
+    : new Date(unixSeconds * 1000).toISOString().slice(0, 10);
+
+// --- Vercel AI Gateway -------------------------------------------------------
+
+interface GatewayPricing {
+  input?: string;
+  output?: string;
+  input_cache_read?: string;
+  input_cache_write?: string;
+}
+interface GatewayModel {
+  id?: string;
+  name?: string;
+  released?: number;
+  context_window?: number;
+  pricing?: GatewayPricing;
+}
+/** `GET https://ai-gateway.vercel.sh/v1/models`. */
+export interface GatewayApi {
+  data?: GatewayModel[];
 }
 
-function resolveLiteLLMProvider(model: LiteLLMModel, slug: string): string {
-  return (
-    vendorFromSlug(slug) ??
-    LITELLM_PROVIDER_MAP[model.litellm_provider ?? ""] ??
-    model.litellm_provider ??
-    "unknown"
-  );
-}
-
-function isLiteLLMModel(value: unknown): value is LiteLLMModel {
-  return typeof value === "object" && value !== null;
-}
-
-const perToken = (v?: number): number | undefined =>
-  v == null ? undefined : v * 1_000_000;
-
-export function normaliseLiteLLM(table: LiteLLMTable): ModelEntry[] {
-  // Dedupe (provider, id) across bedrock/vertex duplicates: first priced wins.
-  const seen = new Map<string, ModelEntry>();
-  for (const [key, value] of Object.entries(table)) {
-    if (key === "sample_spec" || !isLiteLLMModel(value)) continue;
-    const input = perToken(value.input_cost_per_token);
-    const output = perToken(value.output_cost_per_token);
-    if (input == null || output == null) continue;
-
-    const slug = bareSlug(key);
-    const provider = resolveLiteLLMProvider(value, slug);
-    const mapKey = `${provider}\0${slug}`;
-    if (seen.has(mapKey)) continue;
-
-    seen.set(mapKey, {
-      provider,
-      id: slug,
-      rate: {
-        input,
-        output,
-        cacheRead: perToken(value.cache_read_input_token_cost) ?? 0,
-        cacheWrite: perToken(value.cache_creation_input_token_cost) ?? 0,
-      },
-      contextLimit: value.max_input_tokens,
-      source: "litellm",
+/**
+ * Normalise the AI Gateway catalogue.
+ *
+ * Ids are uniformly `owner/model`, so the provider needs no inference — a large
+ * part of why this replaced the LiteLLM adapter. Vercel documents Gateway as
+ * zero-markup ("tokens at exact provider list price"), so these are vendor list
+ * rates rather than a reseller's.
+ */
+export function normaliseAIGateway(api: GatewayApi): ModelEntry[] {
+  const entries: ModelEntry[] = [];
+  for (const model of api.data ?? []) {
+    const slash = model.id?.indexOf("/") ?? -1;
+    if (!model.id || slash <= 0) continue;
+    const input = perTokenStr(model.pricing?.input);
+    const output = perTokenStr(model.pricing?.output);
+    entries.push({
+      provider: model.id.slice(0, slash),
+      id: model.id.slice(slash + 1),
+      displayName: model.name,
+      rate:
+        input != null && output != null
+          ? {
+              input,
+              output,
+              cacheRead: perTokenStr(model.pricing?.input_cache_read) ?? 0,
+              cacheWrite: perTokenStr(model.pricing?.input_cache_write) ?? 0,
+            }
+          : undefined,
+      contextLimit: model.context_window,
+      releaseDate: isoDay(model.released),
+      source: "gateway",
     });
   }
-  return [...seen.values()];
+  return entries;
+}
+
+// --- OpenRouter --------------------------------------------------------------
+
+interface OpenRouterPricing {
+  prompt?: string;
+  completion?: string;
+  input_cache_read?: string;
+  input_cache_write?: string;
+}
+interface OpenRouterModel {
+  id: string;
+  name?: string;
+  created?: number;
+  context_length?: number;
+  pricing?: OpenRouterPricing;
+}
+/** `GET https://openrouter.ai/api/v1/models`. */
+export interface OpenRouterApi {
+  data?: OpenRouterModel[];
+}
+
+/**
+ * Normalise the OpenRouter catalogue. Same `vendor/model` id shape as Gateway.
+ * Carries a handful of vendor-internal slugs the other sources miss entirely
+ * (e.g. the `gpt-5.6-*-pro` variants), which is the reason it is in the merge.
+ */
+export function normaliseOpenRouter(api: OpenRouterApi): ModelEntry[] {
+  const entries: ModelEntry[] = [];
+  for (const model of api.data ?? []) {
+    const slash = model.id.indexOf("/");
+    if (slash <= 0) continue;
+    const input = perTokenStr(model.pricing?.prompt);
+    const output = perTokenStr(model.pricing?.completion);
+    entries.push({
+      provider: model.id.slice(0, slash),
+      id: model.id.slice(slash + 1),
+      displayName: model.name,
+      rate:
+        input != null && output != null
+          ? {
+              input,
+              output,
+              cacheRead: perTokenStr(model.pricing?.input_cache_read) ?? 0,
+              cacheWrite: perTokenStr(model.pricing?.input_cache_write) ?? 0,
+            }
+          : undefined,
+      contextLimit: model.context_length,
+      releaseDate: isoDay(model.created),
+      source: "openrouter",
+    });
+  }
+  return entries;
 }
 
 // --- Merge -----------------------------------------------------------------
@@ -300,48 +325,81 @@ function pick<T>(...values: (T | undefined)[]): T | undefined {
  * a unit from the highest-precedence layer that defines input+output (never
  * mixing input from one source with output from another); names/metadata fill
  * independently from the highest layer that has each.
+ *
+ * In practice the ordering rarely decides anything: across the models actually
+ * in use, the sources were measured to disagree on exactly one rate. It matters
+ * for *coverage*, not arbitration — each layer mostly fills gaps the others
+ * have. models.dev in particular is the only source carrying reseller-routed
+ * providers (OpenCode, Ollama Cloud), which bill at the reseller's rate rather
+ * than the vendor's, so it can never be dropped in favour of a vendor source.
  */
 export function mergeRegistry(sources: {
   overrides: ModelEntry[];
-  litellm: ModelEntry[];
+  gateway: ModelEntry[];
+  openrouter: ModelEntry[];
   modelsDev: ModelEntry[];
 }): ModelEntry[] {
   const override = indexBy(sources.overrides);
-  const litellm = indexBy(sources.litellm);
+  const gateway = indexBy(sources.gateway);
+  const openrouter = indexBy(sources.openrouter);
   const modelsDev = indexBy(sources.modelsDev);
 
   const keys = new Set([
     ...override.keys(),
-    ...litellm.keys(),
+    ...gateway.keys(),
+    ...openrouter.keys(),
     ...modelsDev.keys(),
   ]);
 
   return [...keys].map((key) => {
     const o = override.get(key);
-    const l = litellm.get(key);
+    const g = gateway.get(key);
+    const r = openrouter.get(key);
     const m = modelsDev.get(key);
-    const base = (o ?? l ?? m) as ModelEntry;
+    const base = (o ?? g ?? r ?? m) as ModelEntry;
 
-    // Rates: override > LiteLLM > models.dev, taken whole from the first layer
-    // that fully defines them.
+    // Rates: override > Gateway > OpenRouter > models.dev, taken whole from the
+    // first layer that fully defines them.
     const rateLayer = hasFullRate(o)
       ? o
-      : hasFullRate(l)
-        ? l
-        : hasFullRate(m)
-          ? m
-          : undefined;
+      : hasFullRate(g)
+        ? g
+        : hasFullRate(r)
+          ? r
+          : hasFullRate(m)
+            ? m
+            : undefined;
 
     return {
       provider: base.provider,
       id: base.id,
-      // Names/metadata: override > models.dev > LiteLLM(none)/OpenRouter.
-      displayName: pick(o?.displayName, m?.displayName, l?.displayName),
+      // Names/metadata: override > Gateway > models.dev > OpenRouter.
+      displayName: pick(
+        o?.displayName,
+        g?.displayName,
+        m?.displayName,
+        r?.displayName,
+      ),
       rate: rateLayer?.rate,
-      contextLimit: pick(o?.contextLimit, m?.contextLimit, l?.contextLimit),
-      releaseDate: pick(o?.releaseDate, m?.releaseDate, l?.releaseDate),
-      aliasTarget: pick(o?.aliasTarget, l?.aliasTarget, m?.aliasTarget),
-      source: rateLayer?.source ?? o?.source ?? m?.source ?? base.source,
+      contextLimit: pick(
+        o?.contextLimit,
+        g?.contextLimit,
+        m?.contextLimit,
+        r?.contextLimit,
+      ),
+      releaseDate: pick(
+        o?.releaseDate,
+        g?.releaseDate,
+        m?.releaseDate,
+        r?.releaseDate,
+      ),
+      aliasTarget: pick(
+        o?.aliasTarget,
+        g?.aliasTarget,
+        r?.aliasTarget,
+        m?.aliasTarget,
+      ),
+      source: rateLayer?.source ?? o?.source ?? base.source,
       isOverride: o != null,
     } satisfies ModelEntry;
   });

--- a/packages/usage/src/registry.ts
+++ b/packages/usage/src/registry.ts
@@ -182,14 +182,33 @@ export function canonicalSlug(slug: string): string {
     .replace(/[^a-z0-9]/g, "");
 }
 
-/** Prices arrive as per-token decimal strings; the registry stores USD/1M. */
-const perTokenStr = (v?: string): number | undefined =>
-  v == null ? undefined : Number(v) * 1_000_000;
+/**
+ * Prices arrive as per-token decimal strings; the registry stores USD/1M.
+ *
+ * Anything that is not a finite number becomes `undefined` rather than being
+ * passed through. `Number("")` is `0` and `Number("n/a")` is `NaN`, and both
+ * would otherwise survive the `!= null` checks downstream — Postgres `numeric`
+ * accepts `'NaN'`, so a malformed price would persist and silently poison every
+ * cost computed from it. A genuine zero (free models) is finite and kept.
+ */
+const perTokenStr = (v?: string): number | undefined => {
+  if (v == null || v.trim() === "") return undefined;
+  const perMillion = Number(v) * 1_000_000;
+  return Number.isFinite(perMillion) ? perMillion : undefined;
+};
 
-const isoDay = (unixSeconds?: number): string | undefined =>
-  unixSeconds == null
+/**
+ * Unix seconds → `YYYY-MM-DD`, or `undefined` if the value is not a real date.
+ * `toISOString()` throws a RangeError on an out-of-range date, and that throw
+ * would escape the normaliser and take the entire source down with it.
+ */
+const isoDay = (unixSeconds?: number): string | undefined => {
+  if (unixSeconds == null) return undefined;
+  const date = new Date(unixSeconds * 1000);
+  return Number.isNaN(date.getTime())
     ? undefined
-    : new Date(unixSeconds * 1000).toISOString().slice(0, 10);
+    : date.toISOString().slice(0, 10);
+};
 
 // --- Vercel AI Gateway -------------------------------------------------------
 


### PR DESCRIPTION
Replaces the LiteLLM pricing source with Vercel AI Gateway plus OpenRouter. models.dev stays.

- Delete the LiteLLM adapter — `normaliseLiteLLM`, `bareSlug`, `KNOWN_VENDOR_PREFIXES`, `LITELLM_PROVIDER_MAP`, `vendorFromSlug`, `resolveLiteLLMProvider`. Measured against the 43 `(provider, model)` pairs in use, LiteLLM covers nothing the other sources don't once AI Gateway is present
- Add `normaliseAIGateway`. Vercel documents Gateway as zero-markup, so its rates are vendor list prices, and ids are uniformly `owner/model` so the provider needs no inference. It also supplies display names, release dates and context windows — LiteLLM has none of those
- Restore `normaliseOpenRouter` (removed in #341 as dead code) for a small tail of vendor-internal slugs the others miss
- Add `canonicalSlug` for the punctuation split between sources: Gateway documents dots for versions (`claude-opus-4.8`) where the Anthropic API and our logs use dashes (`claude-opus-4-8`). Consulted only after an exact id miss, so it can never displace an exact hit
- Extract a shared `fetchSourceEntries` helper; three sources meant three near-identical fetch/cache/degrade blocks

**models.dev is not replaceable.** It is the only source carrying the 16 reseller-routed pairs (`opencode`, `opencode-go`, `ollama`), which bill at the reseller's rate. AI Gateway has the underlying models but at vendor prices, so taking them from Gateway would produce confidently wrong numbers.

Verified against all 43 pairs, comparing the new merge to the currently persisted registry:

```
unchanged:      35
NEWLY PRICED:   2   openai/gpt-5.6-terra-pro → 2.5/15
                    openai/gpt-5.6-luna-pro  → 1/6
LOST COVERAGE:  0
RATE CHANGED:   1   openai/gpt-5.1-codex  1.38/11 → 1.25/10
```

Both newly-priced models currently render as N.A. on /usage. The rate change is a correction: LiteLLM was the lone outlier at 1.38/11, while Gateway and OpenRouter independently agree on 1.25/10.

No migration needed — the `source` column's enum is TypeScript-only, and `drizzle-kit check` is clean. `litellm` is retained as a valid value so rows written before this still read back; the next sync rewrites them.

Typecheck, 40 tests and lint all green.

Closes #342