### PR TITLE
Prevent a numeric price from dropping a whole pricing source

### DIFF
--- a/packages/usage/src/__tests__/registry.test.ts
+++ b/packages/usage/src/__tests__/registry.test.ts
@@ -140,6 +140,41 @@ describe("normaliseAIGateway", () => {
     expect(entries[0].releaseDate).toBeUndefined();
     expect(entries[0].rate).toMatchObject({ input: 1, output: 2 });
   });
+
+  it("should accept a price encoded as a number rather than a string", () => {
+    // These payloads are `as`-cast from response.json(), so nothing enforces
+    // the string encoding at runtime, and number is the more natural JSON
+    // encoding for a price — models.dev already sends its costs that way.
+    const [entry] = normaliseAIGateway({
+      data: [
+        { id: "openai/numeric", pricing: { input: 0.000005, output: 0.00001 } },
+      ],
+    });
+    expect(entry.rate).toMatchObject({ input: 5, output: 10 });
+  });
+
+  it("should confine a malformed entry to itself, not drop the source", () => {
+    // A throw escaping the normaliser is caught by the caller's outer handler,
+    // which discards every entry from that source. Losing AI Gateway costs
+    // pricing on every Codex model, since it is their only source.
+    const entries = normaliseAIGateway({
+      data: [
+        {
+          id: "openai/good-1",
+          pricing: { input: "0.000001", output: "0.000002" },
+        },
+        { id: "openai/hostile", pricing: { input: {}, output: [] } as never },
+        {
+          id: "openai/good-2",
+          pricing: { input: "0.000003", output: "0.000004" },
+        },
+      ],
+    });
+    expect(entries).toHaveLength(3);
+    expect(entries[0].rate).toMatchObject({ input: 1, output: 2 });
+    expect(entries[1].rate).toBeUndefined();
+    expect(entries[2].rate).toMatchObject({ input: 3, output: 4 });
+  });
 });
 
 describe("normaliseOpenRouter", () => {

--- a/packages/usage/src/registry.ts
+++ b/packages/usage/src/registry.ts
@@ -183,16 +183,24 @@ export function canonicalSlug(slug: string): string {
 }
 
 /**
- * Prices arrive as per-token decimal strings; the registry stores USD/1M.
+ * Prices arrive per-token; the registry stores USD/1M.
  *
  * Anything that is not a finite number becomes `undefined` rather than being
  * passed through. `Number("")` is `0` and `Number("n/a")` is `NaN`, and both
  * would otherwise survive the `!= null` checks downstream — Postgres `numeric`
  * accepts `'NaN'`, so a malformed price would persist and silently poison every
  * cost computed from it. A genuine zero (free models) is finite and kept.
+ *
+ * The parameter is widened to `string | number` and coerced rather than assumed.
+ * Gateway and OpenRouter both send decimal *strings* today, but these payloads
+ * are `as`-cast straight from `response.json()`, so nothing enforces that at
+ * runtime — and number is the more natural JSON encoding for a price (models.dev
+ * already uses it). Calling a string method on a number here would throw out of
+ * the normaliser and cost the whole source, which is the very failure {@link
+ * isoDay} guards against.
  */
-const perTokenStr = (v?: string): number | undefined => {
-  if (v == null || v.trim() === "") return undefined;
+const perTokenStr = (v?: string | number): number | undefined => {
+  if (v == null || (typeof v === "string" && v.trim() === "")) return undefined;
   const perMillion = Number(v) * 1_000_000;
   return Number.isFinite(perMillion) ? perMillion : undefined;
 };
@@ -212,11 +220,12 @@ const isoDay = (unixSeconds?: number): string | undefined => {
 
 // --- Vercel AI Gateway -------------------------------------------------------
 
+/** Decimal strings today; typed loosely because the payload is `as`-cast. */
 interface GatewayPricing {
-  input?: string;
-  output?: string;
-  input_cache_read?: string;
-  input_cache_write?: string;
+  input?: string | number;
+  output?: string | number;
+  input_cache_read?: string | number;
+  input_cache_write?: string | number;
 }
 interface GatewayModel {
   id?: string;
@@ -268,11 +277,12 @@ export function normaliseAIGateway(api: GatewayApi): ModelEntry[] {
 
 // --- OpenRouter --------------------------------------------------------------
 
+/** Decimal strings today; typed loosely because the payload is `as`-cast. */
 interface OpenRouterPricing {
-  prompt?: string;
-  completion?: string;
-  input_cache_read?: string;
-  input_cache_write?: string;
+  prompt?: string | number;
+  completion?: string | number;
+  input_cache_read?: string | number;
+  input_cache_write?: string | number;
 }
 interface OpenRouterModel {
   id: string;


### PR DESCRIPTION
`perTokenStr` called `v.trim()` on an argument it only assumed was a string. A source encoding a price as a number rather than a decimal string threw a `TypeError` out of the normaliser, which `fetchSourceEntries`'s outer handler caught by discarding **every entry from that source** — not just the offending one.

That is the same blast radius the sibling `isoDay` guard was added to prevent, whose own comment reads *"escaping the normaliser and dropping the whole source rather than one entry"*. So one of the two guards added against a source shifting under us opened a new way for a shifting source to take everything down.

Losing AI Gateway is the expensive case: it is the only source carrying Codex models under the `openai` provider, so dropping it takes pricing off every Codex model on the dashboard.

### Changes

- Coerce rather than assume the type in `perTokenStr`
- Widen `GatewayPricing` and `OpenRouterPricing` to `string | number`. These payloads are `as`-cast straight from `response.json()`, so nothing enforced the string encoding at runtime — and number is the more natural JSON encoding for a price. models.dev already sends its costs that way, so both shapes are in play across the sources today

### Behaviour is otherwise unchanged

Every assertion the existing guard tests make still holds:

| input | result |
|---|---|
| `"0.000005"` | 5 |
| `"n/a"` | undefined |
| `""` | undefined |
| `"0"` | 0 (genuine zero kept) |
| `0.000005` | 5 (**was: TypeError**) |
| absent | undefined |

`isoDay` needed no change — `unixSeconds * 1000` coerces a numeric string harmlessly. Only `perTokenStr` assumed its argument's runtime type.

### Verification

Two regression tests: one for the numeric encoding, one pinning the blast radius (a hostile entry between two healthy ones must leave all three intact). Both **fail against the previous implementation** with the exact `TypeError: v.trim is not a function`, and pass after:

```
=== new tests against PRE-FIX registry.ts ===
  × should accept a price encoded as a number rather than a string
  × should confine a malformed entry to itself, not drop the source
  TypeError: v.trim is not a function
  Tests  2 failed | 44 passed (46)

=== after fix ===
  Tests  46 passed (46)
```

No impact on current data — normalising the live Gateway and OpenRouter catalogues produces zero non-finite rates either way. This is purely future-shift robustness.

Typecheck, tests and lint green across the workspace.

Closes #350