### PR TITLE
Make the registry sync retry a dead source

### DIFF
--- a/apps/web/src/lib/queries/__tests__/models.test.ts
+++ b/apps/web/src/lib/queries/__tests__/models.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/queries/model-registry", () => ({
   upsertModelRegistry,
 }));
 
-import { syncModelRegistry } from "../models";
+import { refreshRegistrySource, syncModelRegistry } from "../models";
 
 const gatewayPayload = {
   data: [
@@ -115,5 +115,34 @@ describe("syncModelRegistry source fetching", () => {
     await syncModelRegistry();
 
     expect(upsertedEntries().some((e) => e.id === "gpt-5-codex")).toBe(true);
+  });
+});
+
+describe("refreshRegistrySource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisSet.mockResolvedValue("OK");
+  });
+
+  it("should reject when the source is unavailable", async () => {
+    // The workflow wraps this in a retrying step, and a step only retries when
+    // it throws. Swallowing the failure here — as this used to — left the step
+    // succeeding with an empty layer on the first transient error, so the retry
+    // it was split out for could never fire.
+    redisGet.mockResolvedValue(null);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    );
+
+    await expect(refreshRegistrySource("gateway")).rejects.toThrow(
+      "AI Gateway returned 503",
+    );
+  });
+
+  it("should report how many entries the source yielded", async () => {
+    redisGet.mockResolvedValue(gatewayPayload);
+
+    await expect(refreshRegistrySource("gateway")).resolves.toBe(1);
   });
 });

--- a/apps/web/src/lib/queries/models.ts
+++ b/apps/web/src/lib/queries/models.ts
@@ -37,6 +37,13 @@ const GATEWAY_CACHE_KEY = "models:gateway";
 const OPENROUTER_CACHE_KEY = "models:openrouter";
 const SOURCE_CACHE_TTL = 86_400;
 
+/** Human-readable source names, for log lines and workflow step messages. */
+export const SOURCE_LABELS: Record<RegistrySource, string> = {
+  gateway: "AI Gateway",
+  openrouter: "OpenRouter",
+  "models.dev": "models.dev",
+};
+
 const PROVIDER_ALIASES: Record<string, string> = {
   ollama: "ollama-cloud",
 };
@@ -96,9 +103,9 @@ export async function syncModelRegistry(): Promise<{
   rows: number;
 }> {
   const [gateway, openrouter, modelsDev, overrides] = await Promise.all([
-    fetchGatewayEntries(),
-    fetchOpenRouterEntries(),
-    fetchModelsDevEntries(),
+    degradeOnFailure(SOURCE_LABELS.gateway, fetchGatewayEntries()),
+    degradeOnFailure(SOURCE_LABELS.openrouter, fetchOpenRouterEntries()),
+    degradeOnFailure(SOURCE_LABELS["models.dev"], fetchModelsDevEntries()),
     loadOverrideEntries(),
   ]);
 
@@ -119,11 +126,12 @@ export async function syncModelRegistry(): Promise<{
  * Warm one source's Redis cache and report how many entries it yielded.
  *
  * Split out so the sync workflow can fetch each source as an independently
- * retryable step. The entries themselves are deliberately *not* returned: a
- * workflow serialises every step result into its journal, and models.dev alone
- * normalises to ~5,800 entries. The subsequent merge step re-reads all three
- * from the Redis cache these calls populate, so only the counts need to cross a
- * step boundary.
+ * retryable step. **Rejects** when the source is unavailable, which is what
+ * makes that retry reachable — the caller degrades once retries run out. The
+ * entries themselves are deliberately *not* returned: a workflow serialises
+ * every step result into its journal, and models.dev alone normalises to ~5,800
+ * entries. The subsequent merge step re-reads all three from the Redis cache
+ * these calls populate, so only the counts need to cross a step boundary.
  */
 export async function refreshRegistrySource(
   source: RegistrySource,
@@ -148,10 +156,16 @@ function seedOverrides(dbOverrides: ModelEntry[]): ModelEntry[] {
 }
 
 /**
- * Fetch one JSON source through the Redis day-cache, normalise it, and degrade
- * to an empty layer on failure. An unavailable source must narrow the merge,
- * never fail the whole sync — the other layers plus the persisted table still
- * produce usable pricing.
+ * Fetch one JSON source through the Redis day-cache and normalise it.
+ *
+ * **Throws** on failure, deliberately. Degrading is the caller's decision, not
+ * this function's, because the two callers want it at different moments: the
+ * sync workflow lets the failure reach its step boundary so the step retries,
+ * and only degrades once those retries are exhausted, while
+ * {@link syncModelRegistry} has no retry machinery behind it and degrades at
+ * once through {@link degradeOnFailure}. Swallowing here made the workflow's
+ * per-source retry unreachable — the step always succeeded, with an empty
+ * layer, on the first transient error.
  */
 async function fetchSourceEntries<T>(
   label: string,
@@ -159,26 +173,38 @@ async function fetchSourceEntries<T>(
   cacheKey: string,
   normalise: (json: T) => ModelEntry[],
 ): Promise<ModelEntry[]> {
-  try {
-    // Read the cache in its own guard. Folding it into the outer try would let
-    // an unreachable or unconfigured Redis discard the source entirely, even
-    // though the HTTP fetch below would have succeeded — which is exactly what
-    // happened on a local ingest run with no Redis credentials: every Codex
-    // model lost pricing because AI Gateway is its only source.
-    const cached = await readCache<T>(cacheKey);
-    if (cached) return normalise(cached);
+  // The cache read guards itself (see `readCache`): an unreachable or
+  // unconfigured Redis must not discard the source when the HTTP fetch below
+  // would have succeeded — which is exactly what happened on a local ingest run
+  // with no Redis credentials, where every Codex model lost pricing because AI
+  // Gateway is its only source.
+  const cached = await readCache<T>(cacheKey);
+  if (cached) return normalise(cached);
 
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`${label} returned ${response.status}`);
-    }
-    const json = (await response.json()) as T;
-    try {
-      await redis.set(cacheKey, json, { ex: SOURCE_CACHE_TTL });
-    } catch {
-      // Pricing can still be built from the fresh response if Redis is down.
-    }
-    return normalise(json);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${label} returned ${response.status}`);
+  }
+  const json = (await response.json()) as T;
+  try {
+    await redis.set(cacheKey, json, { ex: SOURCE_CACHE_TTL });
+  } catch {
+    // Pricing can still be built from the fresh response if Redis is down.
+  }
+  return normalise(json);
+}
+
+/**
+ * Degrade one source to an empty layer. An unavailable source narrows the
+ * merge; the other layers plus the persisted table still produce usable
+ * pricing, so this must never fail the whole sync.
+ */
+async function degradeOnFailure(
+  label: string,
+  entries: Promise<ModelEntry[]>,
+): Promise<ModelEntry[]> {
+  try {
+    return await entries;
   } catch (error) {
     logWarning(`Skipped ${label} source during model registry sync`, {
       error: error instanceof Error ? error.message : String(error),
@@ -205,20 +231,14 @@ function fetchOpenRouterEntries(): Promise<ModelEntry[]> {
   );
 }
 
+/** Throws on failure, for the same reason as {@link fetchSourceEntries}. */
 async function fetchModelsDevEntries(): Promise<ModelEntry[]> {
-  try {
-    const cached = await getCachedPricingApi();
-    if (cached) return normaliseModelsDev(cached);
+  const cached = await getCachedPricingApi();
+  if (cached) return normaliseModelsDev(cached);
 
-    const api = await fetchModelsApi();
-    await cachePricingApi(api);
-    return normaliseModelsDev(api);
-  } catch (error) {
-    logWarning("Skipped models.dev source during model registry sync", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return [];
-  }
+  const api = await fetchModelsApi();
+  await cachePricingApi(api);
+  return normaliseModelsDev(api);
 }
 
 async function loadOverrideEntries(): Promise<ModelEntry[]> {

--- a/apps/web/src/workflows/__tests__/sync-model-registry.steps.test.ts
+++ b/apps/web/src/workflows/__tests__/sync-model-registry.steps.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` factories are hoisted above module scope, so the spies they close
+// over have to be created with `vi.hoisted`.
+const { getStepMetadata, refreshRegistrySource } = vi.hoisted(() => ({
+  getStepMetadata: vi.fn(),
+  refreshRegistrySource: vi.fn(),
+}));
+
+vi.mock("workflow", () => ({ getStepMetadata }));
+
+vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+
+vi.mock("@/lib/logger", () => ({
+  logWarning: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+vi.mock("@/lib/queries/usage", () => ({
+  repriceUnpricedTokenUsage: vi.fn(),
+}));
+
+vi.mock("@/lib/queries/models", () => ({
+  refreshRegistrySource,
+  loadPricing: vi.fn(),
+  syncModelRegistry: vi.fn(),
+  SOURCE_LABELS: {
+    gateway: "AI Gateway",
+    openrouter: "OpenRouter",
+    "models.dev": "models.dev",
+  },
+}));
+
+import { refreshSource } from "../sync-model-registry.steps";
+
+/** The attempt on which a rethrow would fail the run instead of buying a retry. */
+const finalAttempt = (refreshSource.maxRetries ?? 0) + 1;
+
+describe("refreshSource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should report the entry count when the source is healthy", async () => {
+    getStepMetadata.mockReturnValue({ attempt: 1 });
+    refreshRegistrySource.mockResolvedValue(42);
+
+    await expect(refreshSource("gateway")).resolves.toEqual({
+      source: "gateway",
+      entries: 42,
+      degraded: false,
+    });
+  });
+
+  it("should rethrow while attempts remain, so the step retries", async () => {
+    // The whole point of splitting the sources into their own steps. A step
+    // only retries when it throws, so absorbing the error on an early attempt
+    // would spend the retry budget without ever using it.
+    refreshRegistrySource.mockRejectedValue(
+      new Error("AI Gateway returned 503"),
+    );
+
+    for (let attempt = 1; attempt <= finalAttempt - 1; attempt++) {
+      getStepMetadata.mockReturnValue({ attempt });
+      await expect(refreshSource("gateway")).rejects.toThrow(
+        "AI Gateway returned 503",
+      );
+    }
+  });
+
+  it("should degrade on the final attempt rather than fail the run", async () => {
+    // Rethrowing here would reach the orchestrator's `Promise.all` and take the
+    // merge, upsert, reprice and publish steps down with it. One dead source
+    // has to narrow the merge, not lose the other two.
+    getStepMetadata.mockReturnValue({ attempt: finalAttempt });
+    refreshRegistrySource.mockRejectedValue(
+      new Error("AI Gateway returned 503"),
+    );
+
+    await expect(refreshSource("gateway")).resolves.toEqual({
+      source: "gateway",
+      entries: 0,
+      degraded: true,
+    });
+  });
+
+  it("should keep the retry budget and the degrade boundary in step", () => {
+    // These two are only correct relative to each other: degrading a step early
+    // wastes retries, degrading it late fails the run. Pinning the property
+    // stops one moving without the other.
+    expect(refreshSource.maxRetries).toBe(3);
+  });
+});

--- a/apps/web/src/workflows/sync-model-registry.steps.ts
+++ b/apps/web/src/workflows/sync-model-registry.steps.ts
@@ -1,10 +1,12 @@
 import type { RegistrySource } from "@workspace/usage/registry";
 import { revalidateTag } from "next/cache";
+import { getStepMetadata } from "workflow";
 import { ERROR_IDS } from "@/constants/error-ids";
 import { logWarning } from "@/lib/logger";
 import {
   loadPricing,
   refreshRegistrySource,
+  SOURCE_LABELS,
   syncModelRegistry,
 } from "@/lib/queries/models";
 import { repriceUnpricedTokenUsage } from "@/lib/queries/usage";
@@ -23,12 +25,46 @@ import { repriceUnpricedTokenUsage } from "@/lib/queries/usage";
  * Redis cache rather than through the journal.
  */
 
+/** Retries after the first attempt, so a source gets 4 tries in total. */
+const MAX_SOURCE_RETRIES = 3;
+
+/**
+ * Warm one source's cache, retrying a transient outage before giving up on it.
+ *
+ * The failure has to reach this step boundary for the retry to happen at all,
+ * which is why `refreshRegistrySource` rejects rather than degrading. Only once
+ * the attempts are spent does the source degrade to an empty layer, so a source
+ * that stays down narrows the merge instead of failing the run — the property
+ * the inline sync had, now with retries in front of it.
+ *
+ * `degraded` rides back in the step result so an outage is visible in the run's
+ * return value (`npx workflow inspect runs <id>`) rather than only in a log line
+ * nobody reads. Note that a degraded source still lets lower-precedence sources
+ * win the merge for models they both carry, and the upsert is unconditional —
+ * see the follow-up on not downgrading a row when its source is missing.
+ */
 export async function refreshSource(source: RegistrySource) {
   "use step";
 
-  const entries = await refreshRegistrySource(source);
-  return { source, entries };
+  try {
+    const entries = await refreshRegistrySource(source);
+    return { source, entries, degraded: false };
+  } catch (error) {
+    // `attempt` counts from 1 and the runtime stops retrying once it reaches
+    // `maxRetries + 1`, so while it is within that budget a rethrow buys another
+    // attempt. On the final one a rethrow would fail the whole run instead.
+    const { attempt } = getStepMetadata();
+    if (attempt <= MAX_SOURCE_RETRIES) throw error;
+
+    logWarning(`Skipped ${SOURCE_LABELS[source]} after exhausting retries`, {
+      errorId: ERROR_IDS.USAGE_INGEST_FAILED,
+      error: error instanceof Error ? error.message : String(error),
+      attempt,
+    });
+    return { source, entries: 0, degraded: true };
+  }
 }
+refreshSource.maxRetries = MAX_SOURCE_RETRIES;
 
 export async function mergeAndUpsert() {
   "use step";

--- a/apps/web/src/workflows/sync-model-registry.ts
+++ b/apps/web/src/workflows/sync-model-registry.ts
@@ -30,7 +30,8 @@ export async function syncModelRegistryWorkflow() {
   "use workflow";
 
   // One step per source. A source that is down or rate-limited retries on its
-  // own and, if it stays down, narrows the merge rather than failing the run.
+  // own and, if it stays down, narrows the merge rather than failing the run —
+  // reporting `degraded: true` so the run says which layer it went without.
   const sources = await Promise.all(REGISTRY_SOURCES.map(refreshSource));
 
   const { rows } = await mergeAndUpsert();


### PR DESCRIPTION
- Each registry source got its own workflow step in #347 so it could retry independently, but the fetchers caught every error and returned an empty layer — a step only retries when it throws, so the step always succeeded and the retry never fired
- Move the swallow off the fetcher onto the callers, which want it at different moments: `syncModelRegistry` has no retry machinery behind it and degrades immediately as before, while `refreshSource` rethrows while attempts remain and degrades only once they are spent
- Derive the degrade boundary from the runtime (`attempt` counts from 1, retries stop at `maxRetries + 1`) and pin `maxRetries` at 3, so the retry budget and the boundary cannot drift apart
- Report `degraded: true` in the step result so a dead source is visible in the run's return value rather than only in a `logWarning` — the original reason for moving this sync into a workflow
- Add five tests, four of which fail against the pre-fix code, including `promise resolved "+0" instead of rejecting` for the swallowed failure
- Does not stop the merge downgrading rows that a missing source had priced: retries make it rarer, but the upsert is still unconditional, and closing it trades that downgrade against a registry that can wedge into never refreshing — worth its own issue rather than smuggling a policy decision in here

Fixes #353