### PR TITLE
Upsert effortRows on usage ingest

### DIFF
--- a/apps/web/src/app/api/usage/ingest/__tests__/route.test.ts
+++ b/apps/web/src/app/api/usage/ingest/__tests__/route.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/lib/api/mcp-auth", () => ({
 
 vi.mock("@/lib/queries/usage", () => ({
   upsertTokenUsage: vi.fn(),
+  upsertTokenEffortUsage: vi.fn(),
 }));
 
 vi.mock("workflow/api", () => ({
@@ -23,11 +24,12 @@ vi.mock("next/cache", () => ({
 import { revalidateTag } from "next/cache";
 import { start } from "workflow/api";
 import { validateMcpAuth } from "@/lib/api/mcp-auth";
-import { upsertTokenUsage } from "@/lib/queries/usage";
+import { upsertTokenEffortUsage, upsertTokenUsage } from "@/lib/queries/usage";
 import { POST } from "../route";
 
 const mockValidateMcpAuth = vi.mocked(validateMcpAuth);
 const mockUpsertTokenUsage = vi.mocked(upsertTokenUsage);
+const mockUpsertTokenEffortUsage = vi.mocked(upsertTokenEffortUsage);
 const mockStart = vi.mocked(start);
 const mockRevalidateTag = vi.mocked(revalidateTag);
 
@@ -47,6 +49,14 @@ const validRow = {
   messages: 5,
 };
 
+const validEffortRow = {
+  date: "2026-06-02",
+  agent: "claude",
+  levels: [{ level: "high", sessionCount: 2 }],
+  classifiedSessionCount: 2,
+  unclassifiedSessionCount: 1,
+};
+
 function postRequest(body: unknown) {
   return new Request("http://localhost/api/usage/ingest", {
     method: "POST",
@@ -62,6 +72,7 @@ describe("POST /api/usage/ingest", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUpsertTokenUsage.mockResolvedValue(1);
+    mockUpsertTokenEffortUsage.mockResolvedValue(1);
     mockStart.mockResolvedValue({ runId: "run_123" } as Awaited<
       ReturnType<typeof start>
     >);
@@ -103,9 +114,11 @@ describe("POST /api/usage/ingest", () => {
     expect(await response.json()).toEqual({
       ok: true,
       upserted: 1,
+      effortUpserted: 0,
       syncRunId: "run_123",
     });
     expect(mockUpsertTokenUsage).toHaveBeenCalledWith([validRow]);
+    expect(mockUpsertTokenEffortUsage).not.toHaveBeenCalled();
     expect(mockStart).toHaveBeenCalledOnce();
     expect(mockRevalidateTag).toHaveBeenCalledWith("usage", "max");
   });
@@ -133,6 +146,7 @@ describe("POST /api/usage/ingest", () => {
     expect(await response.json()).toEqual({
       ok: true,
       upserted: 1,
+      effortUpserted: 0,
       syncRunId: null,
     });
     expect(mockRevalidateTag).toHaveBeenCalledWith("usage", "max");
@@ -174,5 +188,72 @@ describe("POST /api/usage/ingest", () => {
 
     expect(response.status).toBe(400);
     expect(mockUpsertTokenUsage).not.toHaveBeenCalled();
+  });
+
+  it("should skip effort upsert when effortRows is omitted", async () => {
+    mockValidateMcpAuth.mockResolvedValue({ type: "token" });
+
+    const response = await POST(postRequest({ rows: [validRow] }));
+
+    expect(response.status).toBe(200);
+    expect(mockUpsertTokenUsage).toHaveBeenCalledWith([validRow]);
+    expect(mockUpsertTokenEffortUsage).not.toHaveBeenCalled();
+    expect(await response.json()).toMatchObject({ effortUpserted: 0 });
+  });
+
+  it("should skip effort upsert when effortRows is empty", async () => {
+    mockValidateMcpAuth.mockResolvedValue({ type: "token" });
+
+    const response = await POST(
+      postRequest({ rows: [validRow], effortRows: [] }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpsertTokenUsage).toHaveBeenCalledWith([validRow]);
+    expect(mockUpsertTokenEffortUsage).not.toHaveBeenCalled();
+    expect(await response.json()).toMatchObject({ effortUpserted: 0 });
+  });
+
+  it("should upsert effort rows when provided", async () => {
+    mockValidateMcpAuth.mockResolvedValue({ type: "token" });
+    mockUpsertTokenEffortUsage.mockResolvedValue(1);
+
+    const response = await POST(
+      postRequest({
+        rows: [validRow],
+        effortRows: [validEffortRow],
+        effortSnapshotComplete: true,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockUpsertTokenUsage).toHaveBeenCalledWith([validRow]);
+    expect(mockUpsertTokenEffortUsage).toHaveBeenCalledWith([validEffortRow]);
+    expect(await response.json()).toEqual({
+      ok: true,
+      upserted: 1,
+      effortUpserted: 1,
+      syncRunId: "run_123",
+    });
+  });
+
+  it("should return 400 when effort rows are malformed", async () => {
+    mockValidateMcpAuth.mockResolvedValue({ type: "token" });
+
+    const response = await POST(
+      postRequest({
+        rows: [validRow],
+        effortRows: [
+          {
+            ...validEffortRow,
+            levels: [{ level: "high", sessionCount: -1 }],
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockUpsertTokenUsage).not.toHaveBeenCalled();
+    expect(mockUpsertTokenEffortUsage).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/usage/ingest/route.ts
+++ b/apps/web/src/app/api/usage/ingest/route.ts
@@ -6,7 +6,7 @@ import { handleApiError } from "@/lib/api/errors";
 import { validateMcpAuth } from "@/lib/api/mcp-auth";
 import { parseAndValidateBody } from "@/lib/api/validation";
 import { logWarning } from "@/lib/logger";
-import { upsertTokenUsage } from "@/lib/queries/usage";
+import { upsertTokenEffortUsage, upsertTokenUsage } from "@/lib/queries/usage";
 import { syncModelRegistryWorkflow } from "@/workflows/sync-model-registry";
 
 /**
@@ -27,6 +27,9 @@ import { syncModelRegistryWorkflow } from "@/workflows/sync-model-registry";
  * per-source retries and a visible success/failure record — this route used to
  * do all of it inline behind a `logWarning`, which is how a missing table went
  * unnoticed for a week.
+ *
+ * Optional `effortRows` (AgentUsage) are upserted after token rows when present.
+ * Effort lives inside the same `"usage"` cache tag via `getUsageProfile`.
  */
 export async function POST(request: Request) {
   const auth = await validateMcpAuth(request);
@@ -44,6 +47,10 @@ export async function POST(request: Request) {
 
   try {
     const upserted = await upsertTokenUsage(result.data.rows);
+    const effortUpserted =
+      result.data.effortRows.length > 0
+        ? await upsertTokenEffortUsage(result.data.effortRows)
+        : 0;
 
     // Fire-and-forget: `start` returns as soon as the run is enqueued. The
     // upsert above is the durable operation, so a scheduling failure must not
@@ -62,7 +69,7 @@ export async function POST(request: Request) {
     // Publish the rows just written. The workflow revalidates again once the
     // registry lands, which is what refreshes display names.
     revalidateTag("usage", "max");
-    return Response.json({ ok: true, upserted, syncRunId });
+    return Response.json({ ok: true, upserted, effortUpserted, syncRunId });
   } catch (error) {
     return handleApiError(
       error,

--- a/apps/web/src/lib/queries/__tests__/usage.test.ts
+++ b/apps/web/src/lib/queries/__tests__/usage.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/schema", async () => {
   return { ...actual, db };
 });
 
-import { upsertTokenUsage } from "../usage";
+import { upsertTokenEffortUsage, upsertTokenUsage } from "../usage";
 
 // Mirror the production `db` casing (see schema/index.ts) so embedded columns
 // serialize to their real snake_case names, the way the live query is built.
@@ -48,6 +48,14 @@ const baseRow = {
   totalTokens: 650,
   costUsd: "1.234560",
   messages: 5,
+};
+
+const baseEffortRow = {
+  date: "2026-06-02",
+  agent: "claude",
+  levels: [{ level: "high", sessionCount: 2 }],
+  classifiedSessionCount: 2,
+  unclassifiedSessionCount: 1,
 };
 
 describe("upsertTokenUsage", () => {
@@ -104,5 +112,47 @@ describe("upsertTokenUsage", () => {
     for (const config of onConflictConfigs) {
       expect(config.setWhere).toBeDefined();
     }
+  });
+});
+
+describe("upsertTokenEffortUsage", () => {
+  beforeEach(() => {
+    onConflictConfigs.length = 0;
+  });
+
+  it("should only overwrite when the incoming session total is larger", async () => {
+    await upsertTokenEffortUsage([baseEffortRow]);
+
+    expect(onConflictConfigs).toHaveLength(1);
+    const { setWhere } = onConflictConfigs[0];
+    expect(setWhere).toBeDefined();
+
+    const { sql } = dialect.sqlToQuery(setWhere as never);
+    expect(sql).toBe(
+      '(excluded.classified_session_count + excluded.unclassified_session_count) > ("token_effort_usage"."classified_session_count" + "token_effort_usage"."unclassified_session_count")',
+    );
+  });
+
+  it("should point effort columns at the incoming (excluded) value", async () => {
+    await upsertTokenEffortUsage([baseEffortRow]);
+
+    const { set } = onConflictConfigs[0];
+    for (const column of [
+      "levels",
+      "classifiedSessionCount",
+      "unclassifiedSessionCount",
+    ]) {
+      const { sql } = dialect.sqlToQuery(set[column] as never);
+      expect(sql).toBe(
+        `excluded.${column.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`)}`,
+      );
+    }
+  });
+
+  it("should return 0 and skip the DB when given an empty array", async () => {
+    const submitted = await upsertTokenEffortUsage([]);
+
+    expect(submitted).toBe(0);
+    expect(onConflictConfigs).toHaveLength(0);
   });
 });

--- a/apps/web/src/lib/queries/usage.ts
+++ b/apps/web/src/lib/queries/usage.ts
@@ -13,7 +13,13 @@ import { addDays, differenceInCalendarDays, format, parseISO } from "date-fns";
 import { and, asc, eq, isNull, sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { excludedColumns } from "@/lib/queries/upsert";
-import { db, type InsertTokenUsage, tokenUsage } from "@/schema";
+import {
+  db,
+  type InsertTokenEffortUsage,
+  type InsertTokenUsage,
+  tokenEffortUsage,
+  tokenUsage,
+} from "@/schema";
 
 /** Postgres caps bound parameters per statement; chunk large upserts under it. */
 const UPSERT_CHUNK_SIZE = 1000;
@@ -40,6 +46,21 @@ const UPDATE_COLUMNS = [
   "costUsd",
   "messages",
 ] as const satisfies (keyof typeof tokenUsage.$inferInsert)[];
+
+/**
+ * Composite primary key of `token_effort_usage`.
+ */
+const EFFORT_CONFLICT_TARGET = [
+  tokenEffortUsage.date,
+  tokenEffortUsage.agent,
+] as const;
+
+/** Columns refreshed from the incoming effort row on conflict. */
+const EFFORT_UPDATE_COLUMNS = [
+  "levels",
+  "classifiedSessionCount",
+  "unclassifiedSessionCount",
+] as const satisfies (keyof typeof tokenEffortUsage.$inferInsert)[];
 
 /**
  * Upsert daily `token_usage` aggregates on the composite key
@@ -76,6 +97,41 @@ export async function upsertTokenUsage(
         target: [...CONFLICT_TARGET],
         set,
         setWhere: sql`excluded.total_tokens > ${tokenUsage.totalTokens}`,
+      });
+  }
+  return rows.length;
+}
+
+/**
+ * Upsert daily `token_effort_usage` aggregates on `(date, agent)`.
+ *
+ * Same prune-erosion rationale as {@link upsertTokenUsage}: AgentUsage sends
+ * absolute session-count snapshots recomputed from logs that shrink over time.
+ * A day is overwritten only when the incoming snapshot has a larger
+ * `classifiedSessionCount + unclassifiedSessionCount`. Provided keys only —
+ * unspecified dates are never deleted, even when `effortSnapshotComplete` is
+ * true on the wire.
+ */
+export async function upsertTokenEffortUsage(
+  rows: InsertTokenEffortUsage[],
+): Promise<number> {
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  const set = {
+    ...excludedColumns(tokenEffortUsage, EFFORT_UPDATE_COLUMNS),
+    updatedAt: sql`now()`,
+  };
+  for (let i = 0; i < rows.length; i += UPSERT_CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + UPSERT_CHUNK_SIZE);
+    await db
+      .insert(tokenEffortUsage)
+      .values(chunk)
+      .onConflictDoUpdate({
+        target: [...EFFORT_CONFLICT_TARGET],
+        set,
+        setWhere: sql`(excluded.classified_session_count + excluded.unclassified_session_count) > (${tokenEffortUsage.classifiedSessionCount} + ${tokenEffortUsage.unclassifiedSessionCount})`,
       });
   }
   return rows.length;


### PR DESCRIPTION
- Persist daily session effort via `upsertTokenEffortUsage` with a non-decreasing session-count guard
- Wire `POST /api/usage/ingest` to upsert effort when present and return `effortUpserted`
- Cover omitted, empty, valid, and malformed effort payloads in route and upsert tests

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>