### PR TITLE
Show all-time effort levels on /usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,10 @@ See `packages/usage/src/registry.ts` (pure normalise/merge) and
   touches the local machine). Requires `BLOG_MCP_AUTH_TOKEN` and Vercel's
   `VERCEL_PROJECT_PRODUCTION_URL` (or `VERCEL_URL`) in the environment.
 
+AgentUsage may also POST session-level `effortRows` into `token_effort_usage`
+(alongside token rows); the `/usage` page folds these into an all-time effort
+distribution. Local CLI parsers do not emit effort.
+
 ### MCP Server
 
 - `pnpm mcp` - Start the private workspace MCP server for blog management

--- a/apps/docs/content/docs/usage-ingestion.mdx
+++ b/apps/docs/content/docs/usage-ingestion.mdx
@@ -3,7 +3,7 @@ title: Token Usage Ingestion
 description: Endpoint contract and operator workflow for importing local agent token usage into ruchern.dev.
 ---
 
-The token usage ingestion workflow parses local coding-agent logs, prices the token usage, folds events into daily aggregates, and writes those aggregates into the `token_usage` table.
+The token usage ingestion workflow parses local coding-agent logs, prices the token usage, folds events into daily aggregates, and writes those aggregates into the `token_usage` table. AgentUsage may also POST session-level effort aggregates into `token_effort_usage`.
 
 Parsing happens locally because agent logs live on the machine that ran the agents. Production writes happen through the deployed API route, so the production `DATABASE_URL` never has to be present on a local machine.
 
@@ -30,7 +30,7 @@ The static bearer token is the expected path for production ingestion.
 
 ## Request Body
 
-The body must match `UsageIngestPayload` from `@workspace/usage/ingest`.
+The body must match `UsageIngestPayload` from `@workspace/usage/ingest`. Field names are **camelCase** (matching AgentUsage Codable and the token-row wire style).
 
 ```json
 {
@@ -49,9 +49,21 @@ The body must match `UsageIngestPayload` from `@workspace/usage/ingest`.
       "costUsd": "0.012345",
       "messages": 3
     }
-  ]
+  ],
+  "effortRows": [
+    {
+      "date": "2026-06-02",
+      "agent": "claude",
+      "levels": [{ "level": "high", "sessionCount": 2 }],
+      "classifiedSessionCount": 2,
+      "unclassifiedSessionCount": 1
+    }
+  ],
+  "effortSnapshotComplete": true
 }
 ```
+
+`effortRows` and `effortSnapshotComplete` are optional (default `[]` / `false`) for older clients. Token `rows` remain required — effort-only POSTs are rejected (`400`).
 
 ## Row Contract
 
@@ -74,19 +86,39 @@ Each row represents one daily aggregate for a specific `(date, agent, provider, 
 
 The request must include at least one row and at most `20,000` rows.
 
+## Effort Row Contract
+
+Each effort row is one daily session-level aggregate for `(date, agent)`. Counts are **sessions**, not requests or tokens — each session contributes its dominant effort level (ties → `mixed`). Levels are open-ended strings (`minimal` | `low` | `medium` | `high` | `xhigh` | `max` | `ultra` | `mixed` | future).
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `date` | `YYYY-MM-DD` string | Local calendar date for the aggregate. |
+| `agent` | string | Coding tool that produced the sessions. |
+| `levels` | array of `{ level, sessionCount }` | Classified sessions by effort level. |
+| `classifiedSessionCount` | non-negative integer | Sessions with a known dominant effort. |
+| `unclassifiedSessionCount` | non-negative integer | Sessions without a classifiable effort. |
+
+`effortSnapshotComplete` is accepted on the wire but does **not** delete unspecified dates — only provided keys are upserted.
+
 ## Idempotency
 
-Ingestion is idempotent. Rows are upserted by the composite key:
+Ingestion is idempotent. Token rows are upserted by the composite key:
 
 ```txt
 date + agent + provider + model
 ```
 
-Re-running ingestion recomputes the aggregates from local logs and overwrites existing rows for the same key. This keeps local logs as the source of truth.
+Effort rows are upserted by:
+
+```txt
+date + agent
+```
+
+**Non-decreasing on conflict.** Both tables guard against prune erosion: a day is overwritten only when the incoming snapshot is more complete — larger `totalTokens` for tokens, or larger `classifiedSessionCount + unclassifiedSessionCount` for effort. Smaller re-parses from pruned logs are ignored. The whole incoming row wins together.
 
 ## Cache Revalidation
 
-After a successful upsert, the route revalidates the `usage` cache tag so the public usage page can pick up the new data.
+After a successful upsert, the route revalidates the `usage` cache tag so the public usage page can pick up the new data (tokens and effort share this tag via `getUsageProfile`).
 
 ## Local Ingestion
 
@@ -96,7 +128,7 @@ Use local ingestion to write directly to the database in `DATABASE_URL`.
 pnpm usage:ingest
 ```
 
-This is intended for a local development branch/database.
+This is intended for a local development branch/database. Local parsers currently emit token rows only; effort rows come from AgentUsage.
 
 ## Production Ingestion
 
@@ -135,7 +167,17 @@ curl -X POST "https://ruchern.dev/api/usage/ingest" \
         "costUsd": "0.012345",
         "messages": 3
       }
-    ]
+    ],
+    "effortRows": [
+      {
+        "date": "2026-06-02",
+        "agent": "claude",
+        "levels": [{ "level": "high", "sessionCount": 2 }],
+        "classifiedSessionCount": 2,
+        "unclassifiedSessionCount": 1
+      }
+    ],
+    "effortSnapshotComplete": true
   }'
 ```
 
@@ -144,9 +186,13 @@ curl -X POST "https://ruchern.dev/api/usage/ingest" \
 ```json
 {
   "ok": true,
-  "upserted": 1
+  "upserted": 1,
+  "effortUpserted": 1,
+  "syncRunId": "run_123"
 }
 ```
+
+`effortUpserted` is `0` when `effortRows` is omitted or empty.
 
 ## Failure Modes
 
@@ -159,6 +205,7 @@ curl -X POST "https://ruchern.dev/api/usage/ingest" \
 ## Source Files
 
 - `packages/usage/src/ingest.ts` defines the wire schema.
-- `apps/web/src/scripts/ingest-usage.ts` parses, prices, folds, and posts rows.
+- `apps/web/src/scripts/ingest-usage.ts` parses, prices, folds, and posts token rows.
 - `apps/web/src/app/api/usage/ingest/route.ts` authenticates and upserts rows.
 - `apps/web/src/lib/queries/usage.ts` performs the chunked upsert and usage profile aggregation.
+- `apps/web/src/schema/token-effort-usage.ts` defines the `token_effort_usage` table.

--- a/apps/web/src/app/(main)/usage/components/__tests__/usage-effort-levels.test.tsx
+++ b/apps/web/src/app/(main)/usage/components/__tests__/usage-effort-levels.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import type { EffortSummary } from "@workspace/usage/types";
+import { describe, expect, it } from "vitest";
+import { UsageEffortLevels } from "../usage-effort-levels";
+
+const classified: EffortSummary = {
+  levels: [
+    { level: "low", sessionCount: 1 },
+    { level: "high", sessionCount: 3 },
+  ],
+  classifiedSessionCount: 4,
+  unclassifiedSessionCount: 2,
+};
+
+const allClassified: EffortSummary = {
+  levels: [{ level: "medium", sessionCount: 5 }],
+  classifiedSessionCount: 5,
+  unclassifiedSessionCount: 0,
+};
+
+describe("UsageEffortLevels", () => {
+  it("should render classified caption and level rows", () => {
+    render(<UsageEffortLevels effort={classified} />);
+
+    expect(screen.getByText("4 of 6 sessions classified.")).toBeInTheDocument();
+    expect(screen.getByText("Low")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByText("1 (25%)")).toBeInTheDocument();
+    expect(screen.getByText("3 (75%)")).toBeInTheDocument();
+  });
+
+  it("should render the all-classified caption", () => {
+    render(<UsageEffortLevels effort={allClassified} />);
+
+    expect(screen.getByText("All 5 sessions classified.")).toBeInTheDocument();
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(main)/usage/components/usage-effort-levels.tsx
+++ b/apps/web/src/app/(main)/usage/components/usage-effort-levels.tsx
@@ -1,0 +1,91 @@
+import { Card, Typography } from "@heroui/react";
+import { formatNumber } from "@workspace/usage/format";
+import { type EffortSummary, effortLevelLabel } from "@workspace/usage/types";
+
+interface UsageEffortLevelsProps {
+  className?: string;
+  effort: EffortSummary;
+}
+
+/** Cycle through HeroUI chart tokens for open-ended effort level lists. */
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+] as const;
+
+const CHART_COLOR_CLASSES = [
+  "bg-[var(--chart-1)]",
+  "bg-[var(--chart-2)]",
+  "bg-[var(--chart-3)]",
+  "bg-[var(--chart-4)]",
+  "bg-[var(--chart-5)]",
+] as const;
+
+/**
+ * All-time session effort distribution. Counts are sessions (dominant effort
+ * per session), matching AgentUsage's EffortLevelsView pattern of per-level
+ * horizontal percentage rows.
+ */
+export function UsageEffortLevels({
+  className,
+  effort,
+}: UsageEffortLevelsProps) {
+  const { levels, classifiedSessionCount, unclassifiedSessionCount } = effort;
+  const totalSessions = classifiedSessionCount + unclassifiedSessionCount;
+  const caption =
+    unclassifiedSessionCount === 0
+      ? `All ${formatNumber(classifiedSessionCount)} sessions classified.`
+      : `${formatNumber(classifiedSessionCount)} of ${formatNumber(totalSessions)} sessions classified.`;
+
+  return (
+    <Card className={className}>
+      <Card.Header>
+        <Card.Title>Effort levels</Card.Title>
+        <Card.Description>{caption}</Card.Description>
+      </Card.Header>
+      <Card.Content>
+        <ul className="flex flex-col gap-4">
+          {levels.map((row, index) => {
+            const pct =
+              classifiedSessionCount > 0
+                ? (row.sessionCount / classifiedSessionCount) * 100
+                : 0;
+            const colorClass =
+              CHART_COLOR_CLASSES[index % CHART_COLOR_CLASSES.length];
+            const color = CHART_COLORS[index % CHART_COLORS.length];
+
+            return (
+              <li className="flex flex-col gap-2" key={row.level}>
+                <div className="flex items-baseline justify-between gap-4">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`size-3 shrink-0 rounded-full ${colorClass}`}
+                    />
+                    <Typography type="body-sm">
+                      {effortLevelLabel(row.level)}
+                    </Typography>
+                  </div>
+                  <Typography color="muted" type="body-sm">
+                    {formatNumber(row.sessionCount)} ({Math.round(pct)}%)
+                  </Typography>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-default">
+                  <div
+                    className="h-full rounded-full transition-[width]"
+                    style={{
+                      width: `${pct}%`,
+                      backgroundColor: color,
+                    }}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </Card.Content>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/usage/page.tsx
+++ b/apps/web/src/app/(main)/usage/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/queries/models";
 import { getUsageProfile } from "@/lib/queries/usage";
 import { UsageBreakdown } from "./components/usage-breakdown";
+import { UsageEffortLevels } from "./components/usage-effort-levels";
 import { UsageHeatmap } from "./components/usage-heatmap";
 import { UsageLastUpdated } from "./components/usage-last-updated";
 import { UsageStats } from "./components/usage-stats";
@@ -16,7 +17,7 @@ import { UsageTrend } from "./components/usage-trend";
 
 const title = "Usage";
 const description =
-  "Tokens and cost across my AI coding agents over time. Aggregates only.";
+  "Tokens, cost, and reasoning effort across my AI coding agents over time. Aggregates only.";
 const canonical = "/usage";
 
 export const metadata: Metadata = {
@@ -65,6 +66,10 @@ export default async function UsagePage() {
         <UsageTokenMix tokenMix={profile.tokenMix} />
         <UsageTrend contributions={profile.contributions} />
       </div>
+
+      {profile.effort && profile.effort.classifiedSessionCount > 0 ? (
+        <UsageEffortLevels effort={profile.effort} />
+      ) : null}
 
       <UsageBreakdown
         providerDisplayNames={providerDisplayNames}

--- a/apps/web/src/lib/queries/usage.ts
+++ b/apps/web/src/lib/queries/usage.ts
@@ -1,13 +1,14 @@
 import type { Pricing } from "@workspace/usage/pricing";
-import type {
-  AgentDayBreakdown,
-  Cost,
-  DayContribution,
-  TokenBreakdown,
-  UsageBreakdownRow,
-  UsageProfile,
-  UsageSummary,
-  YearSummary,
+import {
+  type AgentDayBreakdown,
+  type Cost,
+  type DayContribution,
+  foldEffortSummary,
+  type TokenBreakdown,
+  type UsageBreakdownRow,
+  type UsageProfile,
+  type UsageSummary,
+  type YearSummary,
 } from "@workspace/usage/types";
 import { addDays, differenceInCalendarDays, format, parseISO } from "date-fns";
 import { and, asc, eq, isNull, sql } from "drizzle-orm";
@@ -211,7 +212,8 @@ export async function repriceUnpricedTokenUsage(
 }
 
 /**
- * Build the public `UsageProfile` from the daily `token_usage` aggregates.
+ * Build the public `UsageProfile` from the daily `token_usage` aggregates
+ * (and optional `token_effort_usage` session-level effort rows).
  *
  * Pure read (no mutations). All cost arithmetic treats a `null` `costUsd` as
  * N.A. — it is excluded from sums rather than counted as $0, and a group whose
@@ -223,14 +225,17 @@ export async function getUsageProfile(): Promise<UsageProfile> {
   cacheLife("days");
   cacheTag("usage");
 
-  const rows = await db
-    .select()
-    .from(tokenUsage)
-    .orderBy(
-      asc(tokenUsage.date),
-      asc(tokenUsage.agent),
-      asc(tokenUsage.model),
-    );
+  const [rows, effortRows] = await Promise.all([
+    db
+      .select()
+      .from(tokenUsage)
+      .orderBy(
+        asc(tokenUsage.date),
+        asc(tokenUsage.agent),
+        asc(tokenUsage.model),
+      ),
+    db.select().from(tokenEffortUsage),
+  ]);
 
   if (rows.length === 0) {
     return emptyProfile();
@@ -285,6 +290,12 @@ export async function getUsageProfile(): Promise<UsageProfile> {
   const years = buildYears(contributions);
   const summary = buildSummary(contributions, byAgent, byProvider, byModel);
 
+  for (const row of effortRows) {
+    if (row.updatedAt > lastUpdated) {
+      lastUpdated = row.updatedAt;
+    }
+  }
+
   return {
     summary,
     years,
@@ -293,6 +304,7 @@ export async function getUsageProfile(): Promise<UsageProfile> {
     byProvider,
     byModel,
     tokenMix,
+    effort: foldEffortSummary(effortRows),
     lastUpdated: lastUpdated.toISOString(),
   };
 }
@@ -614,6 +626,7 @@ function emptyProfile(): UsageProfile {
     byProvider: [],
     byModel: [],
     tokenMix: emptyTokenBreakdown(),
+    effort: null,
     lastUpdated: null,
   };
 }

--- a/packages/usage/src/__tests__/effort.test.ts
+++ b/packages/usage/src/__tests__/effort.test.ts
@@ -3,6 +3,7 @@ import { usageIngestSchema } from "../ingest";
 import {
   compareEffortLevels,
   effortLevelLabel,
+  foldEffortSummary,
   sortEffortLevels,
 } from "../types";
 
@@ -140,5 +141,54 @@ describe("effort display helpers", () => {
   it("should compare mixed as last", () => {
     expect(compareEffortLevels("ultra", "mixed")).toBeLessThan(0);
     expect(compareEffortLevels("mixed", "alpha")).toBeGreaterThan(0);
+  });
+});
+
+describe("foldEffortSummary", () => {
+  it("should return null for an empty row list", () => {
+    expect(foldEffortSummary([])).toBeNull();
+  });
+
+  it("should return null when no sessions were classified", () => {
+    expect(
+      foldEffortSummary([
+        {
+          levels: [],
+          classifiedSessionCount: 0,
+          unclassifiedSessionCount: 4,
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it("should sum levels across days and keep display order", () => {
+    const summary = foldEffortSummary([
+      {
+        levels: [
+          { level: "high", sessionCount: 2 },
+          { level: "low", sessionCount: 1 },
+        ],
+        classifiedSessionCount: 3,
+        unclassifiedSessionCount: 1,
+      },
+      {
+        levels: [
+          { level: "high", sessionCount: 1 },
+          { level: "mixed", sessionCount: 1 },
+        ],
+        classifiedSessionCount: 2,
+        unclassifiedSessionCount: 0,
+      },
+    ]);
+
+    expect(summary).toEqual({
+      levels: [
+        { level: "low", sessionCount: 1 },
+        { level: "high", sessionCount: 3 },
+        { level: "mixed", sessionCount: 1 },
+      ],
+      classifiedSessionCount: 5,
+      unclassifiedSessionCount: 1,
+    });
   });
 });

--- a/packages/usage/src/types.ts
+++ b/packages/usage/src/types.ts
@@ -126,6 +126,11 @@ export interface UsageProfile {
   byModel: UsageBreakdownRow[];
   /** All-time tokens split by category, for the token-mix bar. */
   tokenMix: TokenBreakdown;
+  /**
+   * All-time session effort distribution, or `null` when no effort rows exist
+   * or no sessions were classified.
+   */
+  effort: EffortSummary | null;
   /** ISO timestamp of the most recent ingest, or null if no data. */
   lastUpdated: string | null;
 }
@@ -212,4 +217,47 @@ export function sortEffortLevels(
   levels: EffortLevelCount[],
 ): EffortLevelCount[] {
   return levels.toSorted((a, b) => compareEffortLevels(a.level, b.level));
+}
+
+/**
+ * Fold daily effort rows into an all-time summary. Returns `null` when there
+ * are no rows or zero classified sessions.
+ */
+export function foldEffortSummary(
+  rows: ReadonlyArray<{
+    levels: EffortLevelCount[];
+    classifiedSessionCount: number;
+    unclassifiedSessionCount: number;
+  }>,
+): EffortSummary | null {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const levelTotals = new Map<string, number>();
+  let classifiedSessionCount = 0;
+  let unclassifiedSessionCount = 0;
+
+  for (const row of rows) {
+    classifiedSessionCount += row.classifiedSessionCount;
+    unclassifiedSessionCount += row.unclassifiedSessionCount;
+    for (const { level, sessionCount } of row.levels) {
+      levelTotals.set(level, (levelTotals.get(level) ?? 0) + sessionCount);
+    }
+  }
+
+  if (classifiedSessionCount === 0) {
+    return null;
+  }
+
+  return {
+    levels: sortEffortLevels(
+      [...levelTotals.entries()].map(([level, sessionCount]) => ({
+        level,
+        sessionCount,
+      })),
+    ),
+    classifiedSessionCount,
+    unclassifiedSessionCount,
+  };
 }


### PR DESCRIPTION
- Fold `token_effort_usage` into `UsageProfile.effort` with all-time session distribution
- Render a HeroUI effort-levels card on `/usage` when classified sessions exist
- Document `effortRows` semantics and correct non-decreasing upsert wording in usage-ingestion docs

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>