### PR TITLE
Add instant navigations shell for blog posts

### DIFF
--- a/apps/web/src/app/(main)/blog/[slug]/components/post-article.tsx
+++ b/apps/web/src/app/(main)/blog/[slug]/components/post-article.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from "@heroui/react";
 import { InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { format, formatISO } from "date-fns";
@@ -13,11 +14,61 @@ import { getPublishedPostBySlug } from "@/lib/queries/posts";
 import { PostToc } from "./post-toc.client";
 
 /**
+ * Content-shaped shell for Instant Navigations while params resolve and the
+ * cached article streams in. Mirrors PostArticle layout (card + TOC column).
+ */
+export function PostArticleFallback() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading post"
+      className="mx-auto flex w-full max-w-[1200px] items-start justify-center gap-11"
+    >
+      <div aria-hidden="true" className="hidden w-53 shrink-0 lg:block" />
+      <SurfaceCard className="flex min-w-0 flex-col gap-8">
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-4 w-40 rounded-lg" />
+          <Skeleton className="h-10 w-full max-w-xl rounded-lg" />
+          <Skeleton className="h-10 w-3/4 max-w-lg rounded-lg" />
+        </div>
+        <div className="flex flex-col gap-3 rounded-xl border border-border bg-default/50 p-5">
+          <Skeleton className="h-4 w-full rounded-lg" />
+          <Skeleton className="h-4 w-5/6 rounded-lg" />
+        </div>
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-4 w-full rounded-lg" />
+          <Skeleton className="h-4 w-full rounded-lg" />
+          <Skeleton className="h-4 w-11/12 rounded-lg" />
+          <Skeleton className="h-4 w-full rounded-lg" />
+          <Skeleton className="h-4 w-4/5 rounded-lg" />
+        </div>
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-4 w-full rounded-lg" />
+          <Skeleton className="h-4 w-full rounded-lg" />
+          <Skeleton className="h-4 w-2/3 rounded-lg" />
+        </div>
+      </SurfaceCard>
+      <aside aria-hidden="true" className="hidden w-53 shrink-0 lg:block">
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-4 w-24 rounded-lg" />
+          <Skeleton className="h-3 w-full rounded-lg" />
+          <Skeleton className="h-3 w-5/6 rounded-lg" />
+          <Skeleton className="h-3 w-4/5 rounded-lg" />
+          <Skeleton className="h-3 w-full rounded-lg" />
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+/**
  * The full article, cached and prerendered per slug so it lands in the static
  * HTML instead of streaming behind a skeleton. Keyed by `post:${slug}` and
  * `mdx:${slug}` so the existing invalidation (see cache-invalidation.ts) busts
- * it on publish/update. Rendered directly (no Suspense) — for slugs in
- * generateStaticParams this fills at build time; unknown slugs render on demand.
+ * it on publish/update. The page wraps this in Suspense with
+ * {@link PostArticleFallback} so Instant Navigations can paint the shell while
+ * params resolve; for slugs in generateStaticParams the cache fills at build
+ * time, unknown slugs render on demand.
  */
 export async function PostArticle({ slug }: { slug: string }) {
   "use cache";

--- a/apps/web/src/app/(main)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/blog/[slug]/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import {
   getPublishedPostBySlug,
   getPublishedPostSlugs,
 } from "@/lib/queries/posts";
-import { PostArticle } from "./components/post-article";
+import { PostArticle, PostArticleFallback } from "./components/post-article";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -54,7 +55,19 @@ export async function generateStaticParams() {
   return publishedPosts.map(({ slug }) => ({ slug }));
 }
 
-export default async function PostPage({ params }: PageProps) {
+/**
+ * Sync shell so Instant Navigations can paint the post layout immediately.
+ * Params + existence/`notFound` stay in the Suspense child (outside `"use cache"`).
+ */
+export default function PostPage({ params }: PageProps) {
+  return (
+    <Suspense fallback={<PostArticleFallback />}>
+      <PostPageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function PostPageContent({ params }: PageProps) {
   const { slug } = await params;
 
   // Existence check outside any `use cache` scope so notFound() (a thrown


### PR DESCRIPTION
- Move `params` await behind Suspense so `/blog/[slug]` can share an App Shell
- Add a content-shaped `PostArticleFallback` for Instant Navigations
- Stacks on #361