### PR TITLE
Rename SG Cars Trends to MotorMetrics

### DIFF
--- a/apps/web/src/app/components/home/project-fan.tsx
+++ b/apps/web/src/app/components/home/project-fan.tsx
@@ -45,8 +45,8 @@ export function ProjectFan() {
         className="h-[150px] w-full md:w-44 md:-rotate-4 md:opacity-85 lg:w-50"
       />
       <FanCard
-        title="SG Cars Trends"
-        label="sgcarstrends.com"
+        title="MotorMetrics"
+        label="motormetrics.app"
         className="z-2 h-50 w-full transition-transform hover:-translate-y-1 md:w-60 lg:w-70"
       />
       <FanCard

--- a/apps/web/src/data/projects.ts
+++ b/apps/web/src/data/projects.ts
@@ -2,8 +2,8 @@ import type { Project } from "@/types";
 
 const projects: Project[] = [
   {
-    name: "SG Cars Trends",
-    slug: "sgcarstrends",
+    name: "MotorMetrics",
+    slug: "motormetrics",
     description:
       "Statistics and analytics platform for car trends in Singapore. Data sourced from Land Transport Authority (LTA).",
     skills: [
@@ -16,8 +16,8 @@ const projects: Project[] = [
       "Upstash Redis",
     ],
     links: [
-      "https://sgcarstrends.com",
-      "https://github.com/sgcarstrends/sgcarstrends",
+      "https://motormetrics.app",
+      "https://github.com/motormetrics/motormetrics",
     ],
     featured: true,
   },


### PR DESCRIPTION
- Update project name, slug, site URL, and GitHub link to MotorMetrics branding
- Reflect the rename on the homepage project fan card