### PR TITLE
Make usage heatmap cells pressable on mobile

### DIFF
--- a/apps/web/src/app/(main)/usage/components/heatmap-grid.client.tsx
+++ b/apps/web/src/app/(main)/usage/components/heatmap-grid.client.tsx
@@ -41,6 +41,10 @@ interface HeatmapGridClientProps {
  * A caption under the grid tracks the hovered/focused day and spells out the
  * press affordance — a heatmap otherwise reads as decoration, and the popover
  * is the only way to reach a day's breakdown.
+ *
+ * The grid keeps its cell size and scrolls horizontally when the container is
+ * too narrow for a full year, rather than shrinking cells to fit. A press
+ * target is the whole point here, so width is the thing that gives.
  */
 export function HeatmapGridClient({
   layout,
@@ -51,49 +55,66 @@ export function HeatmapGridClient({
   const [preview, setPreview] = useState<DayContribution | null>(null);
 
   // One stretchable column per week so the grid fills its container's full
-  // width; cells stay square via `aspect-square`.
-  const columns = `repeat(${weeks.length}, minmax(0, 1fr))`;
+  // width; cells stay square via `aspect-square`. The floor matters more than
+  // the ceiling: with 53 columns and a 4px gap, `minmax(0, …)` leaves the gaps
+  // eating three quarters of a phone's width and collapses cells to ~1px, far
+  // too small to press. Below the floor the grid scrolls instead of shrinking.
+  // The floor itself comes from `--heatmap-cell` so it can differ by breakpoint.
+  const columns = `repeat(${weeks.length}, minmax(var(--heatmap-cell), 1fr))`;
 
   return (
     <div className="flex w-full flex-col gap-2">
-      {/* Month labels: one slot per week column, label at its start column. */}
-      <div
-        className="grid gap-1 text-muted text-xs"
-        style={{ gridTemplateColumns: columns }}
-      >
-        {weeks.map((_, weekIndex) => {
-          const month = monthLabels.find((m) => m.weekIndex === weekIndex);
-          return (
-            <div
-              className="h-4"
-              // biome-ignore lint/suspicious/noArrayIndexKey: week columns are positional
-              key={weekIndex}
-            >
-              {month?.label}
-            </div>
-          );
-        })}
+      {/* Both rows share `columns`, so they stay column-aligned inside the one
+          scroller. The caption sits outside it and stays put while you scroll.
+          The padding is clearance, not spacing: `overflow-x` resolves the
+          vertical axis to `auto` as well, which would otherwise crop the hover
+          scale and focus ring on the edge cells.
+
+          A thumb needs more than a cursor does, so phones get the larger floor
+          and scroll. From `sm` up the floor sits under the width a desktop card
+          settles at, leaving those layouts filling their container as before. */}
+      <div className="flex flex-col gap-2 overflow-x-auto p-1.5 [--heatmap-cell:16px] sm:[--heatmap-cell:10px]">
+        {/* Month labels: one slot per week column, label at its start column. */}
+        <div
+          className="grid gap-1 text-muted text-xs"
+          style={{ gridTemplateColumns: columns }}
+        >
+          {weeks.map((_, weekIndex) => {
+            const month = monthLabels.find((m) => m.weekIndex === weekIndex);
+            return (
+              <div
+                className="h-4"
+                // biome-ignore lint/suspicious/noArrayIndexKey: week columns are positional
+                key={weekIndex}
+              >
+                {month?.label}
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          className="grid grid-flow-col grid-rows-7 gap-1"
+          style={{ gridTemplateColumns: columns }}
+        >
+          {weeks.map((week, weekIndex) =>
+            week.map((cell, dayIndex) => (
+              <Cell
+                cell={cell}
+                modelDisplayNames={modelDisplayNames}
+                onPreview={setPreview}
+                today={today}
+                // biome-ignore lint/suspicious/noArrayIndexKey: grid position is the identity
+                key={`${weekIndex}-${dayIndex}`}
+              />
+            )),
+          )}
+        </div>
       </div>
 
-      <div
-        className="grid grid-flow-col grid-rows-7 gap-1"
-        style={{ gridTemplateColumns: columns }}
-      >
-        {weeks.map((week, weekIndex) =>
-          week.map((cell, dayIndex) => (
-            <Cell
-              cell={cell}
-              modelDisplayNames={modelDisplayNames}
-              onPreview={setPreview}
-              today={today}
-              // biome-ignore lint/suspicious/noArrayIndexKey: grid position is the identity
-              key={`${weekIndex}-${dayIndex}`}
-            />
-          )),
-        )}
-      </div>
-
-      <p className="h-5 text-sm">
+      {/* Reserved height, so swapping days never shifts the layout. Narrow
+          screens need two lines for the same caption, hence the breakpoint. */}
+      <p className="min-h-10 text-sm sm:min-h-5">
         {preview ? (
           <>
             <span className="font-medium">

--- a/apps/web/src/app/(main)/usage/components/heatmap-grid.client.tsx
+++ b/apps/web/src/app/(main)/usage/components/heatmap-grid.client.tsx
@@ -23,7 +23,7 @@ import type {
   ModelDayBreakdown,
 } from "@workspace/usage/types";
 import { format, parseISO } from "date-fns";
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 interface HeatmapGridClientProps {
   layout: HeatmapLayout;
@@ -53,6 +53,45 @@ export function HeatmapGridClient({
 }: HeatmapGridClientProps) {
   const { weeks, monthLabels } = layout;
   const [preview, setPreview] = useState<DayContribution | null>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
+  // The day worth opening on: today while viewing the year that contains it,
+  // otherwise the last day of that year. Deriving it as a plain date also gives
+  // the effect below a dependency that changes on a year switch.
+  const anchorDate = useMemo(() => {
+    const dates = weeks.flatMap((week) =>
+      week.map((cell) => cell.date).filter((date) => date !== null),
+    );
+    return today && dates.includes(today) ? today : (dates.at(-1) ?? null);
+  }, [weeks, today]);
+
+  // When the year does not fit, opening on January is the least useful view: in
+  // August that is eight months of empty cells. Assigning scrollLeft keeps this
+  // inside the scroller, where `scrollIntoView` would drag the whole page down
+  // to the heatmap on load.
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller || !anchorDate) {
+      return;
+    }
+
+    const furthest = scroller.scrollWidth - scroller.clientWidth;
+    if (furthest <= 0) {
+      return;
+    }
+
+    const anchor = scroller.querySelector(`[data-date="${anchorDate}"]`);
+    if (!anchor) {
+      scroller.scrollLeft = furthest;
+      return;
+    }
+
+    // Right-align the anchor, so the run-up to it is what fills the view.
+    const cell = anchor.getBoundingClientRect();
+    const view = scroller.getBoundingClientRect();
+    const offset = cell.right - view.left + scroller.scrollLeft;
+    scroller.scrollLeft = Math.min(furthest, offset - scroller.clientWidth);
+  }, [anchorDate]);
 
   // One stretchable column per week so the grid fills its container's full
   // width; cells stay square via `aspect-square`. The floor matters more than
@@ -73,7 +112,10 @@ export function HeatmapGridClient({
           A thumb needs more than a cursor does, so phones get the larger floor
           and scroll. From `sm` up the floor sits under the width a desktop card
           settles at, leaving those layouts filling their container as before. */}
-      <div className="flex flex-col gap-2 overflow-x-auto p-1.5 [--heatmap-cell:16px] sm:[--heatmap-cell:10px]">
+      <div
+        className="flex flex-col gap-2 overflow-x-auto p-1.5 [--heatmap-cell:16px] sm:[--heatmap-cell:10px]"
+        ref={scrollerRef}
+      >
         {/* Month labels: one slot per week column, label at its start column. */}
         <div
           className="grid gap-1 text-muted text-xs"
@@ -159,6 +201,7 @@ function Cell({
     return (
       <div
         className={cn("aspect-square w-full rounded-sm", INTENSITY_CLASSES[0])}
+        data-date={day.date}
       />
     );
   }
@@ -171,6 +214,8 @@ function Cell({
     <Popover>
       <Popover.Trigger
         aria-label={`${isToday ? "Today, " : ""}${label}: ${formatTokens(day.totals.tokens)} tokens, ${formatCost(day.totals.cost)}, ${formatNumber(day.totals.messages)} messages`}
+        // Scroll anchor for the grid; see the effect in HeatmapGridClient.
+        data-date={day.date}
         onBlur={() => onPreview(null)}
         onFocus={() => onPreview(day)}
         onPointerEnter={() => onPreview(day)}


### PR DESCRIPTION
- Floor the heatmap column width via a `--heatmap-cell` custom property and scroll the grid when it cannot fit, rather than shrinking cells: 16px on phones where a thumb needs the room, 10px from `sm` up. `minmax(0, 1fr)` had let 52 gaps of 4px eat 208px of a 278px grid, leaving 1.31px cells at 390px and making the #369 popover unreachable
- Open on the most recent week instead of January, anchored on today or on year end once the year is over
- Give the caption two lines below `sm`; its fixed `h-5` could not hold the wrapped text and overlapped the legend
- Verified at 390px that the popover opens on tap and lands inside the viewport, that 2026 opens on Jun-Aug with today in view, and that switching to 2025 lands on Oct-Dec
- Middle of the `/usage` mobile stack: based on #369, carries #371