### PR TITLE
Stop breakdown pagination overflowing the page on mobile

### DIFF
--- a/apps/web/src/app/(main)/usage/components/usage-breakdown.tsx
+++ b/apps/web/src/app/(main)/usage/components/usage-breakdown.tsx
@@ -529,7 +529,12 @@ function BreakdownPagination({
   rowsPerPage: number;
 }) {
   return (
-    <div className="flex items-center justify-between gap-4 whitespace-nowrap text-xs">
+    // Stacks rather than overflows: the pager plus the rows-per-page select
+    // need ~410px, and `whitespace-nowrap` on a single row pushed that width
+    // onto the page itself, scrolling every section sideways on a phone.
+    // Stacking beats wrapping here because the pager grows to fill the row,
+    // which would wrap the select onto its own line at every width.
+    <div className="flex flex-col gap-2 whitespace-nowrap text-xs sm:flex-row sm:items-center sm:justify-between sm:gap-4">
       <Pagination size="sm">
         <Pagination.Content>
           <Pagination.Item>


### PR DESCRIPTION
- Stack the breakdown pager and rows-per-page select below `sm`, single row from `sm` up. Together they needed ~410px on one `whitespace-nowrap` row inside a 278px card, pushing the whole document to 466px against a 390px viewport, which is what threw every `/usage` section off-centre
- Stacked rather than wrapped because the pager `<nav>` grows to fill the row, so `flex-wrap` pushed the select onto its own line at every width, desktop included
- Top of the `/usage` mobile stack: #369 to #370 to this