### PR TITLE
Add Grok 4.6 and xAI provider support

### DIFF
--- a/apps/web/src/lib/queries/models.ts
+++ b/apps/web/src/lib/queries/models.ts
@@ -46,6 +46,7 @@ export const SOURCE_LABELS: Record<RegistrySource, string> = {
 
 const PROVIDER_ALIASES: Record<string, string> = {
   ollama: "ollama-cloud",
+  "x-ai": "xai",
 };
 
 const FALLBACK_PROVIDER_NAMES: Record<string, string> = {
@@ -58,6 +59,8 @@ const FALLBACK_PROVIDER_NAMES: Record<string, string> = {
   opencode: "OpenCode Zen",
   "opencode-go": "OpenCode Go",
   openai: "OpenAI",
+  xai: "xAI",
+  "x-ai": "xAI",
 };
 
 interface ModelsProviderMetadata {

--- a/packages/usage/src/__tests__/pricing.test.ts
+++ b/packages/usage/src/__tests__/pricing.test.ts
@@ -8,11 +8,12 @@ import {
 
 /**
  * Fixture mirroring the models.dev payload shape. `gpt-5.5` is priced under both
- * `openai` and `fireworks-ai` to prove provider selection. The GPT-5.6 entries
- * deliberately carry incorrect rates so the tests prove the seeded overrides
- * take precedence. `gpt-5.5-fast` and `claude-sonnet-5` are absent from
- * models.dev, so they resolve only via the seeded override entries — exactly
- * as they do in production once merged from `SEED_OVERRIDES`.
+ * `openai` and `fireworks-ai` to prove provider selection. The GPT-5.6 and
+ * Grok 4.6 entries deliberately carry incorrect rates so the tests prove the
+ * seeded overrides take precedence. `gpt-5.5-fast`, `claude-sonnet-5`, and
+ * `grok-4.6-fast` are absent from models.dev, so they resolve only via the
+ * seeded override entries — exactly as they do in production once merged from
+ * `SEED_OVERRIDES`.
  */
 const api: ModelsDevApi = {
   anthropic: {
@@ -36,6 +37,11 @@ const api: ModelsDevApi = {
     models: {
       "gpt-5.5": { cost: { input: 99, output: 99 } },
       "gpt-5.6-sol": { cost: { input: 98, output: 98 } },
+    },
+  },
+  xai: {
+    models: {
+      "grok-4.6": { cost: { input: 91, output: 91 } },
     },
   },
 };
@@ -199,6 +205,52 @@ describe("buildPricingFromRegistry", () => {
       { provider: "openai" },
     );
     expect(cost).toBeCloseTo(88.75, 6);
+  });
+
+  it("should pin exact Grok 4.6 rates ahead of models.dev", () => {
+    expect(pricing.priceFor("grok-4.6", { provider: "xai" })).toEqual({
+      input: 2,
+      output: 6,
+      cacheRead: 0.5,
+      cacheWrite: 0,
+    });
+    expect(pricing.priceFor("grok-4.6-fast", { provider: "xai" })).toEqual({
+      input: 4,
+      output: 12,
+      cacheRead: 1,
+      cacheWrite: 0,
+    });
+  });
+
+  it("should scope Grok 4.6 overrides to the xAI provider", () => {
+    expect(pricing.priceFor("grok-4.6", { provider: "openai" })).toBeNull();
+    expect(
+      pricing.priceFor("grok-4.6-fast", { provider: "cursor" }),
+    ).toBeNull();
+  });
+
+  it("should price the Grok 4.6 dash slug identically to the dotted id", () => {
+    expect(pricing.priceFor("grok-4-6", { provider: "xai" })).toEqual(
+      pricing.priceFor("grok-4.6", { provider: "xai" }),
+    );
+  });
+
+  it("should price every Grok 4.6 token bucket at its pinned rate", () => {
+    const cost = pricing.costOf(
+      {
+        input: 1_000_000,
+        output: 1_000_000,
+        cacheRead: 1_000_000,
+        cacheWrite: 0,
+        reasoning: 1_000_000,
+      },
+      "grok-4.6",
+      { provider: "xai" },
+    );
+
+    // $2 input + $6 output + $0.50 cache read + $6 reasoning (billed as output)
+    // = $14.50.
+    expect(cost).toBeCloseTo(14.5, 6);
   });
 
   it("should price every GPT-5.6 token bucket at its pinned rate", () => {

--- a/packages/usage/src/__tests__/providers.test.ts
+++ b/packages/usage/src/__tests__/providers.test.ts
@@ -30,6 +30,7 @@ describe("providerLogoUrl", () => {
     expect(providerLogoUrl("anthropic")).toBe(
       "https://models.dev/logos/anthropic.svg",
     );
+    expect(providerLogoUrl("xai")).toBe("https://models.dev/logos/xai.svg");
   });
 });
 

--- a/packages/usage/src/__tests__/registry.test.ts
+++ b/packages/usage/src/__tests__/registry.test.ts
@@ -49,6 +49,8 @@ describe("canonicalSlug", () => {
     expect(canonicalSlug("gpt-5.6-sol")).not.toBe(
       canonicalSlug("gpt-5.6-sol-fast"),
     );
+    expect(canonicalSlug("grok-4.6")).toBe(canonicalSlug("grok-4-6"));
+    expect(canonicalSlug("grok-4.6")).not.toBe(canonicalSlug("grok-4.6-fast"));
     expect(canonicalSlug("claude-opus-4-8")).not.toBe(
       canonicalSlug("claude-opus-5"),
     );

--- a/packages/usage/src/providers.ts
+++ b/packages/usage/src/providers.ts
@@ -5,8 +5,9 @@ import type { Provider } from "./types";
  * tokens. Used as a fallback for agents that do NOT record a provider per event.
  *
  * Multi-provider agents (e.g. OpenCode, which routes to openai, fireworks-ai,
- * ollama, opencode, opencode-go) instead carry the provider on each usage event,
- * so they are not listed here — see {@link resolveProvider}.
+ * ollama, opencode, opencode-go; Cursor, which stamps `xai` for grok-* models)
+ * instead carry the provider on each usage event, so they are not listed here —
+ * see {@link resolveProvider}.
  *
  * Consumed by the ingest fold (to stamp `provider` on each row) and pricing (to
  * resolve a model under its provider on models.dev). Add a single-provider

--- a/packages/usage/src/registry.ts
+++ b/packages/usage/src/registry.ts
@@ -51,9 +51,9 @@ export type ModelSource =
  * layer only where the DB has no curated override for the key, so local + prod
  * self-seed on first ingest and each row becomes MCP-editable data afterward.
  *
- * These are all OpenAI Codex-internal slugs (or `claude-sonnet-5` before
- * models.dev listed it) that appear in no public pricing source, so they can
- * only ever be overrides. Rates are USD per 1,000,000 tokens.
+ * These are slugs that appear in no public pricing source, or newly-released
+ * frontier models whose live rates we pin until the sources settle (GPT-5.6,
+ * Grok 4.6). Rates are USD per 1,000,000 tokens.
  */
 export const SEED_OVERRIDES: ModelEntry[] = [
   {
@@ -104,6 +104,22 @@ export const SEED_OVERRIDES: ModelEntry[] = [
     source: "override",
     isOverride: true,
     aliasTarget: "gpt-5-codex",
+  },
+  {
+    provider: "xai",
+    id: "grok-4.6",
+    source: "override",
+    isOverride: true,
+    displayName: "Grok 4.6",
+    rate: { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
+  },
+  {
+    provider: "xai",
+    id: "grok-4.6-fast",
+    source: "override",
+    isOverride: true,
+    displayName: "Grok 4.6 Fast",
+    rate: { input: 4, output: 12, cacheRead: 1, cacheWrite: 0 },
   },
 ];
 


### PR DESCRIPTION
- Pin Grok 4.6 and Grok 4.6 Fast list prices under the xAI provider so /usage can cost those rows
- Add an xAI display-name fallback and map OpenRouter's `x-ai` alias so the Provider tab labels correctly